### PR TITLE
Add mtproxy database

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -31,6 +31,8 @@ import:
 	-terraform import module.aiven_postgres.aiven_pg_user.outline_user romashov-tech/romashov-tech-postgres/outline-user
 	-terraform import module.aiven_postgres.aiven_pg_database.vault romashov-tech/romashov-tech-postgres/romashov-tech-vault
 	-terraform import module.aiven_postgres.aiven_pg_user.vault_user romashov-tech/romashov-tech-postgres/vault-user
+	-terraform import module.aiven_postgres.aiven_pg_database.mtproxy_production romashov-tech/romashov-tech-postgres/mtproxy-production
+	-terraform import module.aiven_postgres.aiven_pg_user.mtproxy_user romashov-tech/romashov-tech-postgres/mtproxy-production
 	@echo "--- OCI VM ---"
 	terraform import 'module.oci_vm.oci_core_instance.this' 'ocid1.instance.oc1.eu-stockholm-1.anqxeljryneafxycu45rfs7efir6uaw6cmpydknxiw25ph35fil254kkejgq'
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 ## Модули
 
 - **aiven-mysql** — Aiven MySQL (сервис, БД, пользователи)
-- **aiven-postgres** — Aiven Postgres (сервис, БД, пользователи)
+- **aiven-postgres** — Aiven Postgres (сервис, БД, пользователи). В том числе БД **mtproxy-production** и пользователь **mtproxy-production** для хранения секретов MTProxy (права CONNECT/CREATE на БД и USAGE/CREATE на схему public выдаются при apply через null_resource + psql под avnadmin).
 - **oci-iam** — IAM-политика для compute/network
 - **oci-vm** — Oracle Cloud (одна VM sweden-node, Ubuntu 22.04). VM и подсеть в существующей VCN **vcn-20250808-1700** (подсеть создаётся Terraform, если в VCN её ещё нет).
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,6 +45,7 @@ module "aiven_postgres" {
   pg_inventory_user_password = var.pg_inventory_user_password
   pg_outline_user_password   = var.pg_outline_user_password
   pg_vault_user_password     = var.pg_vault_user_password
+  pg_mtproxy_user_password   = var.pg_mtproxy_user_password
 }
 
 # OCI: аутентификация из переменных (terraform.tfvars или backend.conf)

--- a/terraform/modules/aiven-postgres/main.tf
+++ b/terraform/modules/aiven-postgres/main.tf
@@ -70,3 +70,39 @@ resource "aiven_pg_user" "vault_user" {
   password             = var.pg_vault_user_password
   pg_allow_replication = false
 }
+
+# MTProxy: отдельная БД и пользователь для хранения секретов MTProxy
+resource "aiven_pg_database" "mtproxy_production" {
+  project       = aiven_pg.this.project
+  service_name  = aiven_pg.this.service_name
+  database_name = "mtproxy-production"
+}
+
+resource "aiven_pg_user" "mtproxy_user" {
+  project              = aiven_pg.this.project
+  service_name         = aiven_pg.this.service_name
+  username             = "mtproxy-production"
+  password             = var.pg_mtproxy_user_password
+  pg_allow_replication = false
+}
+
+# Права пользователя mtproxy-production на БД mtproxy-production (CONNECT + CREATE на БД и схему public).
+# Выполняется через psql под avnadmin (service_uri), т.к. Aiven не даёт выдать права через Terraform provider.
+resource "null_resource" "mtproxy_grants" {
+  depends_on = [
+    aiven_pg_database.mtproxy_production,
+    aiven_pg_user.mtproxy_user,
+  ]
+  triggers = {
+    db   = aiven_pg_database.mtproxy_production.database_name
+    user = aiven_pg_user.mtproxy_user.username
+  }
+  provisioner "local-exec" {
+    environment = {
+      PGCONN_POSTGRES = replace(aiven_pg.this.service_uri, "defaultdb", "postgres")
+      PGCONN_MTPROXY  = replace(aiven_pg.this.service_uri, "defaultdb", "mtproxy-production")
+    }
+    command     = "psql \"$PGCONN_POSTGRES\" -v ON_ERROR_STOP=1 -c 'GRANT CONNECT, CREATE ON DATABASE \"mtproxy-production\" TO \"mtproxy-production\";' && psql \"$PGCONN_MTPROXY\" -v ON_ERROR_STOP=1 -c 'GRANT USAGE, CREATE ON SCHEMA public TO \"mtproxy-production\";'"
+    interpreter = ["bash", "-c"]
+  }
+}

--- a/terraform/modules/aiven-postgres/provider.tf
+++ b/terraform/modules/aiven-postgres/provider.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "aiven/aiven"
       version = ">=4.0.0, <5.0.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }
 

--- a/terraform/modules/aiven-postgres/variables.tf
+++ b/terraform/modules/aiven-postgres/variables.tf
@@ -32,3 +32,8 @@ variable "pg_vault_user_password" {
   description = "Password for Postgres vault-user"
   type        = string
 }
+
+variable "pg_mtproxy_user_password" {
+  description = "Password for Postgres mtproxy-production user (MTProxy secrets DB)"
+  type        = string
+}

--- a/terraform/terraform.example.tfvars
+++ b/terraform/terraform.example.tfvars
@@ -6,6 +6,7 @@ pg_foodikal_user_password  = ""
 pg_inventory_user_password = ""
 pg_outline_user_password   = ""
 pg_vault_user_password     = ""
+pg_mtproxy_user_password   = ""
 
 mysql_avnadmin_user_password   = ""
 mysql_monitoring_user_password = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,6 +42,11 @@ variable "pg_vault_user_password" {
   type        = string
 }
 
+variable "pg_mtproxy_user_password" {
+  description = "Password for Postgres mtproxy-production user (MTProxy secrets DB)"
+  type        = string
+}
+
 # OCI (аутентификация через переменные в terraform.tfvars / backend.conf)
 variable "oci_tenancy_ocid" {
   description = "OCI tenancy OCID"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a dedicated Aiven Postgres DB and user `mtproxy-production` for MTProxy secrets, with grants applied during apply. Also adds a new password variable and updates imports and docs.

- New Features
  - Provision Postgres DB `mtproxy-production` and user `mtproxy-production`.
  - Apply grants via `null_resource` + `psql` (CONNECT/CREATE on DB; USAGE/CREATE on schema `public`).
  - Add `pg_mtproxy_user_password` variable and example in `terraform.example.tfvars`; add Makefile import targets; update README.

- Dependencies
  - Add `hashicorp/null` provider to the `aiven-postgres` module.

<sup>Written for commit 385ce49072f7f2a647a999f41c4f9913f9e1ef36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

