### PR TITLE
feat(3x-ui): stop publishing host ports on inbound 3xui_app

### DIFF
--- a/ansible/roles/3x-ui/templates/docker-compose.in.yaml.j2
+++ b/ansible/roles/3x-ui/templates/docker-compose.in.yaml.j2
@@ -4,12 +4,10 @@ services:
     container_name: 3xui_app
     hostname: "{{ fqdn }}"
     expose:
-      - 6432
       - 443
-    ports:
-      - 2053:2053
-      - 6432:6432
-      - 443:443
+      - 2053
+      - 2096
+      - 6432
     volumes:
       - 3xui_db:/etc/x-ui/
       - $PWD/cert/:/root/cert/


### PR DESCRIPTION
## Summary

- Drop `ports:` (2053, 6432, 443) from the inbound 3x-ui compose template.
- Traffic now reaches the container only via the `romashovtech_default` docker network, fronted by traefik.
- `expose:` lists 443/2053/2096/6432 so docker DNS still resolves `3xui_app` from inside the network.

Pairs with framebassman/romashov-tech#309 (adds the TCP-passthrough routers in traefik). **Deploy that PR first** — otherwise this redeploy releases 443/2053 before traefik claims them and VLESS goes down briefly.

## Test plan

- [x] `ansible-playbook --syntax-check playbooks/deploy-3x-ui.yml` → OK
- [x] Template renders to valid compose (jinja2 + yaml safe_load)
- [ ] After deploy: `docker ps --filter name=3xui_app --format '{{.Ports}}'` shows no host bindings
- [ ] After deploy: traefik can reach `3xui_app:443/2053/2096/6432`

This PR was created with AI assistance.