### PR TITLE
feat(3x-ui): move panel from :6432 to :80 via x-ui CLI

### DIFF
--- a/ansible/roles/3x-ui/defaults/main.yml
+++ b/ansible/roles/3x-ui/defaults/main.yml
@@ -2,3 +2,4 @@
 fqdn: ""
 direction: ""
 backup_retention_count: 5
+xui_panel_port: 80

--- a/ansible/roles/3x-ui/tasks/main.yml
+++ b/ansible/roles/3x-ui/tasks/main.yml
@@ -20,3 +20,25 @@
     services:
       - 3xui
   register: output
+
+- name: Read current 3x-ui panel port
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      docker exec 3xui_app /app/x-ui setting -show | awk -F': ' '/^port:/{print $2}'
+    executable: /bin/bash
+  register: xui_current_port
+  changed_when: false
+
+- name: Set 3x-ui panel port to {{ xui_panel_port }}
+  ansible.builtin.command:
+    cmd: docker exec 3xui_app /app/x-ui setting -port {{ xui_panel_port }}
+  when: xui_current_port.stdout | trim | int != xui_panel_port
+
+- name: Restart 3x-ui so the new panel port takes effect
+  community.docker.docker_compose_v2:
+    project_src: /home/d.romashov/3x-ui
+    services:
+      - 3xui
+    state: restarted
+  when: xui_current_port.stdout | trim | int != xui_panel_port

--- a/ansible/roles/3x-ui/templates/docker-compose.in.yaml.j2
+++ b/ansible/roles/3x-ui/templates/docker-compose.in.yaml.j2
@@ -4,10 +4,10 @@ services:
     container_name: 3xui_app
     hostname: "{{ fqdn }}"
     expose:
+      - 80
       - 443
       - 2053
       - 2096
-      - 6432
     volumes:
       - 3xui_db:/etc/x-ui/
       - $PWD/cert/:/root/cert/


### PR DESCRIPTION
## Summary

Move 3x-ui admin panel listen port from 6432 to 80 on both \`in\` (node2, docker bridge) and \`out\` (NL, host network) deployments.

### Changes

- \`roles/3x-ui/defaults/main.yml\`: \`xui_panel_port: 80\`
- \`roles/3x-ui/templates/docker-compose.in.yaml.j2\`: expose 80 instead of 6432 (no host port published — internal docker network only).
- \`roles/3x-ui/tasks/main.yml\`: idempotent panel-port enforcement
  - read current port via \`/app/x-ui setting -show\`
  - if it differs, run \`/app/x-ui setting -port {{ xui_panel_port }}\` and \`docker compose restart 3xui\`

The DB lives in the named volume \`3xui_db\` so the setting persists across container recreates.

## Pairs with

framebassman/romashov-tech (new PR) — switches the traefik backend URLs from \`:6432\` to \`:80\`. **Merge the infrastructure PR first**, then the proxy PR.

## Out-node note

The out container runs \`network_mode: host\`. The panel will bind \`0.0.0.0:80\` on the NL host's public IP. Same exposure level as before (was \`0.0.0.0:6432\`), different port.

## Test plan

- [x] \`ansible-playbook --syntax-check\` OK
- [x] Template renders to valid compose; expose list = [80, 443, 2053, 2096]
- [ ] After deploy: \`docker exec 3xui_app /app/x-ui setting -show\` shows \`port: 80\` on both nodes
- [ ] After proxy redeploy: \`https://in.romashov.tech\` and \`https://out.romashov.tech\` still serve the panel

This PR was created with AI assistance.