### PR TITLE
feat(monitoring): ansible deploy-monitoring playbook + Makefile target

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -25,6 +25,10 @@ deploy-3x-ui:
 	make requirements
 	ansible-playbook playbooks/deploy-3x-ui.yml
 
+deploy-monitoring:
+	make requirements
+	ansible-playbook playbooks/deploy-monitoring.yml
+
 backup-3x-ui:
 	make requirements
 	ansible-playbook playbooks/backup-3x-ui.yml \

--- a/ansible/playbooks/deploy-monitoring.yml
+++ b/ansible/playbooks/deploy-monitoring.yml
@@ -1,0 +1,9 @@
+---
+- hosts: sweden
+  become: true
+  become_user: d.romashov
+  vars:
+    application: monitoring
+    project_path: "/home/d.romashov/romashov-tech"
+  roles:
+    - romashov-tech-deployment


### PR DESCRIPTION
Pairs with framebassman/romashov-tech#318. Adds `playbooks/deploy-monitoring.yml` (targets sweden, reuses romashov-tech-deployment role) and a `deploy-monitoring` Makefile entry. Deploy this first so uptime-kuma is up on sweden by the time the proxy redeploy drops it from node2.

This PR was created with AI assistance.