### PR TITLE
feat(terraform): NSG on sweden VNIC, allow :80 from node2 for monitoring

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,8 +86,33 @@ resource "oci_core_subnet" "default_vcn" {
 module "oci_vm" {
   source    = "./modules/oci-vm/"
   subnet_id = oci_core_subnet.default_vcn.id
+  nsg_ids   = [oci_core_network_security_group.sweden_inbound.id]
 
   depends_on = [module.oci_iam]
+}
+
+# NSG для sweden-node: входящий доступ к публичным сервисам, ограниченный по source IP.
+# Combined with the VCN default security list as UNION at evaluation time.
+resource "oci_core_network_security_group" "sweden_inbound" {
+  compartment_id = local.oci_compartment_id
+  vcn_id         = data.oci_core_vcns.default.virtual_networks[0].id
+  display_name   = "sweden-inbound"
+}
+
+# monitoring (uptime-kuma на host:80) — фронтит traefik с node2.
+resource "oci_core_network_security_group_security_rule" "sweden_monitoring_from_node2" {
+  network_security_group_id = oci_core_network_security_group.sweden_inbound.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source_type               = "CIDR_BLOCK"
+  source                    = "109.172.90.19/32"
+  description               = "monitoring (uptime-kuma) reverse-proxied from node2"
+  tcp_options {
+    destination_port_range {
+      min = 80
+      max = 80
+    }
+  }
 }
 
 # Бюджет $5 и алерт при достижении (для контроля расходов при PAYG)

--- a/terraform/modules/oci-vm/main.tf
+++ b/terraform/modules/oci-vm/main.tf
@@ -56,6 +56,7 @@ EOT
     assign_public_ip       = local.assign_public_ip
     hostname_label         = local.instance_display_name
     skip_source_dest_check = false
+    nsg_ids                = var.nsg_ids
   }
 
   source_details {

--- a/terraform/modules/oci-vm/variables.tf
+++ b/terraform/modules/oci-vm/variables.tf
@@ -3,3 +3,9 @@ variable "subnet_id" {
   description = "OCID подсети (из корня: oci_core_subnet.default_vcn.id)"
   type        = string
 }
+
+variable "nsg_ids" {
+  description = "OCID списка NSG для primary VNIC. Combined with subnet security list (UNION) at evaluation time."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

The existing OCI security lists on the sweden VCN only allow \`:22\` + ICMP inbound, so the docker-published port for monitoring was blocked at the cloud firewall regardless of host iptables (verified: \`curl localhost:3001\` on sweden → 302, \`curl public-ip:3001\` → timeout from anywhere).

Add an NSG on the sweden VNIC with one ingress rule:

| Direction | Protocol | Source | Port |
|-----------|----------|--------|------|
| INGRESS   | TCP      | \`109.172.90.19/32\` (node2) | 80 |

Combined with the VCN's default security list (UNION semantics in OCI), this opens \`:80\` only for node2, leaving the rest of the public internet rejected as before.

The oci-vm module gains an optional \`nsg_ids\` variable, threaded into \`create_vnic_details.nsg_ids\`. Updating NSG attachment is in-place — no VM rebuild.

## Pairs with

framebassman/romashov-tech (port-80 fix PR) — switches monitoring host port from 3001 to 80 and updates traefik backend URL.

## Test plan

- [x] \`terraform fmt -recursive\` (no diff)
- [x] \`terraform validate\` OK
- [ ] CI \`terraform apply -auto-approve\` succeeds
- [ ] After full deploy: \`curl -I http://79.76.37.36:80\` from node2 → 302 (uptime-kuma redirect)
- [ ] \`curl -I http://79.76.37.36:80\` from arbitrary IP → still timed out (NSG denies)
- [ ] \`https://monitoring.romashov.tech\` → uptime-kuma login

This PR was created with AI assistance.