### PR TITLE
fix(monitoring): retarget playbook at node1; drop unused sweden NSG

### DIFF
--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -27,3 +27,7 @@ _3xui:
     185.121.233.152:
       fqdn: out.3x.romashov.tech
       direction: out
+monitoring:
+  hosts:
+    91.84.124.164:
+      fqdn: node1.romashov.tech

--- a/ansible/playbooks/deploy-monitoring.yml
+++ b/ansible/playbooks/deploy-monitoring.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: sweden
+- hosts: monitoring
   become: true
   become_user: d.romashov
   vars:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,33 +86,8 @@ resource "oci_core_subnet" "default_vcn" {
 module "oci_vm" {
   source    = "./modules/oci-vm/"
   subnet_id = oci_core_subnet.default_vcn.id
-  nsg_ids   = [oci_core_network_security_group.sweden_inbound.id]
 
   depends_on = [module.oci_iam]
-}
-
-# NSG для sweden-node: входящий доступ к публичным сервисам, ограниченный по source IP.
-# Combined with the VCN default security list as UNION at evaluation time.
-resource "oci_core_network_security_group" "sweden_inbound" {
-  compartment_id = local.oci_compartment_id
-  vcn_id         = data.oci_core_vcns.default.virtual_networks[0].id
-  display_name   = "sweden-inbound"
-}
-
-# monitoring (uptime-kuma на host:80) — фронтит traefik с node2.
-resource "oci_core_network_security_group_security_rule" "sweden_monitoring_from_node2" {
-  network_security_group_id = oci_core_network_security_group.sweden_inbound.id
-  direction                 = "INGRESS"
-  protocol                  = "6" # TCP
-  source_type               = "CIDR_BLOCK"
-  source                    = "109.172.90.19/32"
-  description               = "monitoring (uptime-kuma) reverse-proxied from node2"
-  tcp_options {
-    destination_port_range {
-      min = 80
-      max = 80
-    }
-  }
 }
 
 # Бюджет $5 и алерт при достижении (для контроля расходов при PAYG)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -90,6 +90,16 @@ module "oci_vm" {
   depends_on = [module.oci_iam]
 }
 
+# NSG kept here so terraform can detach it from the VNIC in this apply
+# without also racing the NSG delete (which fails while the VNIC still
+# references it). The follow-up PR will remove this empty NSG once the
+# detach has landed.
+resource "oci_core_network_security_group" "sweden_inbound" {
+  compartment_id = local.oci_compartment_id
+  vcn_id         = data.oci_core_vcns.default.virtual_networks[0].id
+  display_name   = "sweden-inbound"
+}
+
 # Бюджет $5 и алерт при достижении (для контроля расходов при PAYG)
 resource "oci_budget_budget" "monthly_limit" {
   compartment_id = var.oci_tenancy_ocid


### PR DESCRIPTION
Pairs with framebassman/romashov-tech#321. New `monitoring` inventory group (node1 NL), playbook target switched, sweden NSG + ingress rule + nsg_ids reverted.

This PR was created with AI assistance.