### PR TITLE
fix(3x-ui): restore backup_retention_count default

### DIFF
--- a/ansible/roles/3x-ui/defaults/main.yml
+++ b/ansible/roles/3x-ui/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Number of newest backup archives to keep in R2 for each host's prefix.
+# Used by tasks/backup.yml when pruning old objects.
+backup_retention_count: 5


### PR DESCRIPTION
Nightly backup-3xui-configs cron started failing with `'backup_retention_count' is undefined` after PR #85 trimmed the role. tasks/backup.yml still uses that variable; re-add only it (not the deploy-only vars that genuinely went away).

This PR was created with AI assistance.