### PR TITLE
docs(claude): CLAUDE.md + diagnose-cross-node-link skill + .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ansible-playbook --syntax-check:*)",
+      "Bash(ansible-inventory --list:*)",
+      "Bash(terraform fmt:*)",
+      "Bash(terraform validate)",
+      "Bash(terraform validate:*)",
+      "Bash(terraform init -backend=false)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh workflow list:*)",
+      "Bash(gh workflow view:*)"
+    ]
+  }
+}

--- a/.claude/skills/diagnose-cross-node-link/SKILL.md
+++ b/.claude/skills/diagnose-cross-node-link/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: diagnose-cross-node-link
+description: Triage cross-host link issues — when a service on host A is reverse-proxied or dialed from host B and it intermittently stalls, returns partial responses, or breaks on large payloads. Already-mapped patterns we hit in this infra (RU↔OCI selective drop, MTU blackholes, NSG firewall denials, container-network DNAT misses).
+---
+
+# Diagnose a cross-node link
+
+Symptoms that should send you here:
+
+- Small HTTP responses (HEAD, redirects, headers) succeed; large bodies stall mid-stream.
+- Browser shows a blank SPA but headers say `200 OK`.
+- traefik logs `Error while handling TCP connection ... readfrom tcp ... use of closed network connection`.
+- `curl --max-time` to a backend through the proxy returns truncated bytes after a fast TTFB.
+
+The 98 KB stall is the canonical "RU↔OCI peering is broken" signature.
+
+## Step 1 — isolate by transfer size
+
+```bash
+# Small response — should be instant
+curl -sS --max-time 5 -o /dev/null -w "HTTP %{http_code} ttfb=%{time_starttransfer}s\n" \
+    -I https://<endpoint>/
+
+# Large response — the actual symptom
+curl -sS --max-time 20 -o /dev/null -w "size=%{size_download}B total=%{time_total}s\n" \
+    https://<endpoint>/<large-asset>
+```
+
+If small=OK and large=stall → packet loss or PMTUD black-hole on the path.
+Continue.
+
+## Step 2 — bypass the proxy
+
+```bash
+ansible -i hosts.yml <proxy-host> -m shell -b \
+    -a 'docker exec proxy wget -q -O /dev/null --timeout=15 http://<backend-host>:<port>/<asset>'
+```
+
+If the same backend asset stalls when fetched directly from the proxy host
+(no traefik in the middle), the issue is on the proxy↔backend network leg,
+not in traefik or the SPA.
+
+## Step 3 — capture retransmits on the backend host
+
+```bash
+ansible -i hosts.yml <backend-host> -m shell -b -a \
+    'timeout 15 tcpdump -i <iface> -n -c 80 "tcp and host <proxy-host-ip> and port <port>"'
+```
+
+Trigger the failing transfer from a client *while* the capture is running.
+Pattern to look for:
+
+```
+IP 10.0.0.204.80 > 109.172.90.19.47634: Flags [.], seq 0:1448, ack 1, ..., length 1448
+IP 10.0.0.204.80 > 109.172.90.19.47634: Flags [.], seq 0:1448, ack 1, ..., length 1448
+IP 10.0.0.204.80 > 109.172.90.19.47634: Flags [.], seq 0:1448, ack 1, ..., length 1448
+```
+
+Same `seq 0:1448` repeated with growing intervals (4 s → 9 s → 18 s) and
+tiny total packet count (3 in 15 s) ⇒ sender keeps shipping, no ACKs come
+back. **In our infra: RU(node2)↔OCI(sweden) link does this.** Treat as
+unfixable on our side — move the service to a non-OCI / non-RU host.
+
+## Step 4 — check MTU on both ends
+
+```bash
+ansible -i hosts.yml <host> -m shell -a 'ip link show <iface> | head -2'
+```
+
+OCI VMs default to MTU 9000 (jumbo). Doesn't usually matter for outbound to
+MTU-1500 paths because TCP MSS clamps from the peer's SYN, but worth
+checking. Transient drop:
+```bash
+ansible -i hosts.yml <host> -m shell -b -a 'ip link set dev <iface> mtu 1500'
+```
+Persist via netplan if it actually helps.
+
+If lowering MTU does NOT change the 98 KB stall → MTU is innocent. Restore
+default and look elsewhere.
+
+## Step 5 — check cloud-provider firewall
+
+If the link works node↔node but fails for a specific source IP:
+
+```bash
+ansible -i hosts.yml <host> -m shell -a \
+    '(timeout 5 bash -c "</dev/tcp/<other-host>/<port>") && echo OPEN || echo CLOSED'
+```
+
+- **OCI**: NSGs attached to the VNIC. Defined in `terraform/main.tf` as
+  `oci_core_network_security_group` + `oci_core_network_security_group_security_rule`.
+  Rules UNION with the VCN default security list (which only opens `:22`
+  + ICMP by default).
+- **Other VPS providers**: check the provider control panel. OS-level
+  iptables on these hosts is usually permissive.
+
+## Step 6 — container-level DNAT
+
+If a port is `0.0.0.0:<X>->container:<Y>` on the host but external dial
+fails:
+
+```bash
+ansible -i hosts.yml <host> -m shell -b -a \
+    "iptables -t nat -L DOCKER -nv | grep '<X>\\|<Y>'"
+```
+
+Missing DNAT rule means docker proxy created the binding but the iptables
+rule didn't land — `docker compose down && up -d` usually re-creates it.
+
+## Decision table
+
+| Observation                                        | Likely cause                  | Where to fix                                                   |
+|----------------------------------------------------|-------------------------------|----------------------------------------------------------------|
+| Small OK, large stall, retransmits w/ backoff      | L3 path packet loss / sanctions | Move service off the bad route                               |
+| Both stall, fast RST / no route                    | Cloud firewall denial         | Open NSG ingress (terraform/main.tf) or VCN security list      |
+| Both stall, slow timeout                           | Wrong DNS / host not listening | Verify backend URL resolves + service actually binds          |
+| Works from one IP only                             | Source-IP whitelist somewhere | Loosen NSG / check `DOCKER-USER` chain on the backend host    |
+| Stall after fixed N bytes (≈ 98 KB)                | TCP window stuck — no ACKs    | Same as L3 packet loss row — symptom-identical                |
+| "No route to host" via OS-level tcp probe          | NSG denial OR backend not listening | Check NSG rule first; if rule exists, check `ss -lntp` on backend |
+
+## Don'ts
+
+- Don't crank ocserv / xray MTU / MSS knobs to "fix" what is actually
+  path-level loss. The packets get dropped before MSS matters.
+- Don't add a permissive firewall rule "just to test" — once the rule
+  lands on the prod NSG it tends to stay.
+- Don't run `tcpdump -w` to disk on a VM with `<10 GB` free — it fills
+  fast on busy interfaces. Use `-c <count>` or `-G <rotate-seconds>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,139 @@
+# romashov-tech-infrastructure
+
+Orchestration repo. No application code, no docker-compose files. Two halves:
+
+- `ansible/` — deploy / backup / restore playbooks + roles. Inventory in `hosts.yml`.
+- `terraform/` — OCI VM + IAM, Aiven managed databases. State in Cloudflare R2
+  (s3-compatible) at `kolenka-inc-terraform-backend`.
+
+Compose stacks live in the sibling repo `romashov-tech`. The
+`romashov-tech-deployment` role clones it onto each host and runs the
+matching Makefile target at deploy time.
+
+## Standard deploy pattern
+
+Each service has a thin playbook `playbooks/deploy-<service>.yml`:
+```yaml
+- hosts: <inventory-group>
+  become: true
+  become_user: d.romashov
+  vars:
+    application: <make-target-suffix>
+    project_path: /home/d.romashov/romashov-tech
+  roles:
+    - romashov-tech-deployment
+```
+
+The role:
+1. Copies `ssh-config` referencing `~/.ssh/github_actions_id_rsa`.
+2. Clones `romashov-tech` to `project_path` (or `git reset --hard` if it exists).
+3. `make stop-prod-{{ application }}`.
+4. `make start-prod-{{ application }}`.
+5. `docker image prune --all --force`.
+
+To add a new service: new playbook + add `application` matching a Makefile
+target in the app repo. To add a new host: add to `hosts.yml` with `fqdn`,
+copy the GitHub deploy key onto the host before first deploy.
+
+## Inventory groups
+
+| Group        | Hosts                                | Notes                                                  |
+|--------------|--------------------------------------|--------------------------------------------------------|
+| `russian`    | 109.172.90.19 (node2)                | RU edge — traefik + 3x-ui-in                           |
+| `dutch`      | 91.84.124.164 + 185.121.233.152      | NL hosts                                               |
+| `sweden`     | 79.76.37.36 (OCI Stockholm)          | grafana-alloy only — outbound-only                     |
+| `vpn`        | 91.84.124.164 + 109.172.90.19        | openconnect ocserv hosts                               |
+| `mtproxy`    | 91.84.124.164                        | telegram mtproxy                                       |
+| `_3xui`      | 109.172.90.19 + 185.121.233.152      | host var `direction: in|out` picks compose-profile      |
+| `monitoring` | 91.84.124.164                        | uptime-kuma                                            |
+
+Every host has `fqdn` set in inventory — roles assume it.
+
+## CI workflow caveats (`.github/workflows/deploy.yml`)
+
+Triggered on **every `pull_request`** against master:
+1. `apply-terraform-modules` — runs `terraform apply -auto-approve` against
+   real OCI / Aiven state. Will mutate cloud state on every PR, even
+   docs-only PRs.
+2. `apply-infrastructure-playbook` — provisioning basics.
+3. `apply-firewall-playbook` + `apply-3xui-playbook` (in parallel after #2)
+   — both auto-deploy to real hosts. The 3x-ui playbook will recreate
+   `3xui_app` containers (~10s downtime per host).
+
+Implications:
+- A docs-only PR still runs terraform apply. Watch for side effects.
+- To suppress autodeploy on a given PR: `gh run cancel <id>` after opening.
+- The `apply-terraform-modules` job uses
+  `terraform apply -auto-approve`, so any drift between the branch and
+  master will be applied on PR open.
+
+## GitHub deploy keys on hosts
+
+`roles/romashov-tech-deployment/files/ssh-config` references
+`~/.ssh/github_actions_id_rsa`. Every host needs that private key plus a
+matching deploy key registered on the `romashov-tech` repo. When
+provisioning a new host the role fails on `git clone` with
+`Permission denied (publickey)`. Fix:
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/github_actions_id_rsa -N "" -C "github-deploy-<host>"
+cat ~/.ssh/github_actions_id_rsa.pub   # add to GitHub repo Deploy Keys
+```
+
+## OCI sweden quirks
+
+- Uses an existing VCN `vcn-20250808-1700` (not managed by terraform); we
+  attach a subnet + VM only.
+- Subnet's default security list = `:22` + ICMP only. Open extra ports
+  via an NSG (`oci_core_network_security_group` + security rules), attach
+  via `module.oci_vm.nsg_ids`. NSG rules **UNION** with the security list
+  at evaluation time.
+- **Destroy ordering trap**: removing `nsg_ids` from VNIC *and* destroying
+  the NSG in the same plan races — OCI rejects NSG delete while VNIC
+  still references it. Do detach-first apply, then delete in a follow-up
+  PR. There is currently an empty `oci_core_network_security_group
+  "sweden_inbound"` retained for this reason; safe to delete now in a
+  follow-up.
+- Default NIC MTU on OCI is 9000 (jumbo). MSS clamping usually saves us,
+  but keep in mind if a future inbound service shows the 98 KB stall
+  symptom.
+- **RU peering**: do not host services on sweden that need to be
+  reverse-proxied from node2 (RU). Large TCP transfers stall —
+  see `.claude/skills/diagnose-cross-node-link`.
+
+## Backup / restore (3x-ui only)
+
+- `.github/workflows/backup-3x.yml` runs `playbooks/backup-3x-ui.yml`
+  daily at 03:00 UTC.
+- Archive layout: R2 bucket `backups`, key
+  `<fqdn>/backup-YYYY-MM-DDTHH-MM-SS.tar`.
+- Retention: `backup_retention_count` (default 5) defined in
+  `roles/3x-ui/defaults/main.yml`. **Don't delete that file** — backup
+  task depends on it (this cron broke once already when the file was
+  removed during a role-trim).
+- Restore: `playbooks/restore-3x-ui.yml` with
+  `--extra-vars backup_filename=<basename>` (omit for latest).
+- Backup stops the `3xui_app` container before tar-ing the volume on
+  disk → brief downtime during backup window.
+
+## Known issues
+
+- `romashov-tech/.github/workflows/vpn-deploy.yml` path filter has
+  `docker-compose.vpn.yml` without `deploy/` prefix — workflow doesn't
+  fire on the actual compose file changes. Run `make deploy-vpn`
+  manually after vpn.yml edits or fix the path filter.
+- Empty `oci_core_network_security_group "sweden_inbound"` retained in
+  `terraform/main.tf` for the destroy-race reason above. Safe to remove
+  in a follow-up.
+
+## Hard no's
+
+(Apply on top of the workspace-level `claude.md` rules.)
+
+- Do not run `ansible-playbook` against real inventory without `--check`
+  unless explicitly told to in the current turn.
+- Do not run `terraform apply / destroy / state mv / state rm` without
+  explicit OK in the current turn.
+- Do not add `apply-*` CI jobs that run against prod without a manual
+  approval gate.
+- Do not commit `terraform.tfvars`, `backend.conf` in plaintext, or any
+  files containing real secret material.


### PR DESCRIPTION
Codifies orchestration patterns + diagnosis playbook for the hard-to-spot link issues we hit this session. Three files:

- \`CLAUDE.md\` — standard deploy pattern (romashov-tech-deployment role), inventory groups (incl. _3xui direction var), CI auto-deploy caveats (terraform apply -auto-approve on PR), GitHub deploy-key requirement, OCI sweden quirks (NSG/MTU/RU-peering), backup/restore notes (including the recent backup_retention_count incident), hard no's.
- \`.claude/settings.json\` — allowlist for read-only commands (ansible --syntax-check, terraform fmt/validate, gh pr/run/workflow view).
- \`.claude/skills/diagnose-cross-node-link/SKILL.md\` — playbook for the 98 KB-stall pattern: isolate by size → bypass proxy → tcpdump for retransmits → MTU check → cloud firewall check → DNAT check, with a decision table.

Pairs with framebassman/romashov-tech#328 (CLAUDE.md + add-service skill in the application repo).

This PR was created with AI assistance.