### PR TITLE
chore(ansible): add deploy-grafana-alloy make target

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -15,7 +15,8 @@ deploy-vault:
 
 deploy-proxy:
 	make requirements
-	ansible-playbook playbooks/deploy-proxy.yml
+	ansible-playbook playbooks/deploy-proxy.yml \
+		--extra-vars cloudflare_api_token=$${CLOUDFLARE_API_TOKEN}
 
 deploy-mtproxy:
 	make requirements
@@ -28,6 +29,11 @@ deploy-3x-ui:
 deploy-monitoring:
 	make requirements
 	ansible-playbook playbooks/deploy-monitoring.yml
+
+deploy-grafana-alloy:
+	make requirements
+	ansible-playbook playbooks/deploy-grafana-alloy.yml \
+		--extra-vars cloudflare_api_token=$${CLOUDFLARE_API_TOKEN}
 
 backup-3x-ui:
 	make requirements


### PR DESCRIPTION
## Summary
- New \`make deploy-grafana-alloy\` target (matches the rest of \`deploy-*\`)
- Threads \`CLOUDFLARE_API_TOKEN\` env var through to the playbook so the role can write \`.cloudflare\` on the host before \`make fetch-secrets\` runs there
- Same threading added to \`deploy-proxy\` — it now also needs the token because \`make start-prod-proxy\` calls \`fetch-secrets\` (added in romashov-tech #329)
- Empty env is safe: role's \`when: cloudflare_api_token | length > 0\` skips the rewrite and reuses whatever's already on the host

## Test plan
- [x] \`make -n deploy-grafana-alloy\` / \`make -n deploy-proxy\` expand correctly
- [ ] \`terraform plan\` job — should show **0 changes** (no terraform diff in this PR)
- [ ] Real run: \`CLOUDFLARE_API_TOKEN=… make deploy-grafana-alloy\` deploys alloy on sweden

This PR was created with AI assistance.