### PR TITLE
feat(terraform): migrate monitoring to Grafana Cloud SM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,6 @@ copy the GitHub deploy key onto the host before first deploy.
 | `vpn`        | 91.84.124.164 + 109.172.90.19        | openconnect ocserv hosts                               |
 | `mtproxy`    | 91.84.124.164                        | telegram mtproxy                                       |
 | `_3xui`      | 109.172.90.19 + 185.121.233.152      | host var `direction: in|out` picks compose-profile      |
-| `monitoring` | 91.84.124.164                        | uptime-kuma                                            |
 
 Every host has `fqdn` set in inventory — roles assume it.
 

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -26,10 +26,6 @@ deploy-3x-ui:
 	make requirements
 	ansible-playbook playbooks/deploy-3x-ui.yml
 
-deploy-monitoring:
-	make requirements
-	ansible-playbook playbooks/deploy-monitoring.yml
-
 deploy-grafana-alloy:
 	make requirements
 	ansible-playbook playbooks/deploy-grafana-alloy.yml \

--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -27,7 +27,3 @@ _3xui:
     185.121.233.152:
       fqdn: out.3x.romashov.tech
       direction: out
-monitoring:
-  hosts:
-    91.84.124.164:
-      fqdn: node1.romashov.tech

--- a/ansible/playbooks/deploy-monitoring.yml
+++ b/ansible/playbooks/deploy-monitoring.yml
@@ -1,9 +1,0 @@
----
-- hosts: monitoring
-  become: true
-  become_user: d.romashov
-  vars:
-    application: monitoring
-    project_path: "/home/d.romashov/romashov-tech"
-  roles:
-    - romashov-tech-deployment

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -26,7 +26,6 @@ import-cf:
 	-terraform import 'module.cloudflare.cloudflare_record.a_dash' '6d25afe4e74dea9603251aae7971f49f/46706dd6b9a124723e51af04898d14bb'
 	-terraform import 'module.cloudflare.cloudflare_record.a_in_3x' '6d25afe4e74dea9603251aae7971f49f/09a4c5fc355933fd434743df072cf177'
 	-terraform import 'module.cloudflare.cloudflare_record.a_in' '6d25afe4e74dea9603251aae7971f49f/5a9f66e83cf050c916a773a74515b6dc'
-	-terraform import 'module.cloudflare.cloudflare_record.a_monitoring' '6d25afe4e74dea9603251aae7971f49f/3ecffa9f27210bd66cb40e3a7656ffea'
 	-terraform import 'module.cloudflare.cloudflare_record.a_node1' '6d25afe4e74dea9603251aae7971f49f/ae6f92f1f8a0cc9cfab7627f23a7db1b'
 	-terraform import 'module.cloudflare.cloudflare_record.a_node2' '6d25afe4e74dea9603251aae7971f49f/d4b4902abe137ac4fc1e87d88cab4047'
 	-terraform import 'module.cloudflare.cloudflare_record.a_node3' '6d25afe4e74dea9603251aae7971f49f/c103e840258747878e5f73425219ed3e'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "oracle/oci"
       version = "~> 8"
     }
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3"
+    }
   }
 
   backend "s3" {
@@ -32,8 +36,9 @@ variable "account_id" { default = "4faf2c3b5dd13669f97dd976498ad56a" }
 provider "cloudflare" {}
 
 module "cloudflare" {
-  source     = "./modules/cloudflare/"
-  account_id = var.account_id
+  source              = "./modules/cloudflare/"
+  account_id          = var.account_id
+  status_redirect_url = module.grafana_monitoring.public_status_page_url
 }
 
 module "vdsina_ru" {
@@ -154,4 +159,20 @@ resource "oci_budget_alert_rule" "at_5_usd" {
   type           = "ACTUAL"
   message        = "OCI spend has reached $5 this month. Check Cost Analysis in Console."
   recipients     = "dmitry@romashov.tech"
+}
+
+# ── Grafana Cloud (Synthetic Monitoring + Alerting) ──────────────────────────
+# Replaces self-hosted Uptime Kuma on node1. See modules/grafana-monitoring/README.md.
+provider "grafana" {
+  url             = "https://${var.grafana_stack_slug}.grafana.net"
+  auth            = var.grafana_cloud_api_key
+  sm_url          = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
+  sm_access_token = var.grafana_synthetic_monitoring_token
+}
+
+module "grafana_monitoring" {
+  source          = "./modules/grafana-monitoring/"
+  stack_slug      = var.grafana_stack_slug
+  slack_bot_token = var.slack_grafana_bot_token
+  slack_channel   = "general"
 }

--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -50,13 +50,34 @@ resource "cloudflare_record" "a_in" {
   ttl     = 900
 }
 
-resource "cloudflare_record" "a_monitoring" {
+resource "cloudflare_record" "cname_status" {
   zone_id = local.zone_id
-  name    = "monitoring"
-  type    = "A"
-  content = "109.172.90.19"
-  proxied = false
+  name    = "status"
+  type    = "CNAME"
+  content = "romashovtech.grafana.net"
+  # Proxied so the page rule below can rewrite/redirect at CF edge. With
+  # proxied=false the browser would hit grafana.net directly with SNI=
+  # status.romashov.tech and get a cert mismatch (grafana's cert is *.grafana.net).
+  proxied = true
   ttl     = 1
+}
+
+# 302 redirect: status.romashov.tech/* -> the full public-dashboard URL.
+# Required because Grafana Cloud doesn't support custom domains on Free/Pro
+# tiers (Enterprise only); the cleanest fallback for a vanity status URL is
+# an HTTP-level redirect at the CF edge.
+resource "cloudflare_page_rule" "status_redirect" {
+  zone_id  = local.zone_id
+  target   = "status.romashov.tech/*"
+  priority = 1
+  status   = "active"
+
+  actions {
+    forwarding_url {
+      url         = var.status_redirect_url
+      status_code = 302
+    }
+  }
 }
 
 resource "cloudflare_record" "a_node1" {

--- a/terraform/modules/cloudflare/variables.tf
+++ b/terraform/modules/cloudflare/variables.tf
@@ -2,3 +2,8 @@ variable "account_id" {
   description = "Cloudflare account ID"
   type        = string
 }
+
+variable "status_redirect_url" {
+  description = "Full URL the status.romashov.tech page rule redirects to (Grafana Cloud public dashboard). Comes from grafana-monitoring module output."
+  type        = string
+}

--- a/terraform/modules/grafana-monitoring/README.md
+++ b/terraform/modules/grafana-monitoring/README.md
@@ -1,0 +1,53 @@
+# grafana-monitoring
+
+Active uptime probing + alert delivery to Slack, replacing the old self-hosted
+Uptime Kuma instance on node1.
+
+## What it manages
+
+- **Synthetic Monitoring checks** scheduled from Stockholm + Frankfurt public
+  probes at 7-minute intervals (sized to fit Grafana Cloud free-tier
+  100k execs/month; 7 × 2 × (60/420) × 60 × 24 × 30 ≈ 86k/month, ~14k headroom).
+  Stockholm chosen as the closest publicly-available probe to RU — there are no
+  Grafana Cloud probes inside Russia.
+  - 4 × TCP checks on openconnect VPN ports (`node{1..4}.romashov.tech:4443`)
+  - 2 × TCP checks on Reality endpoints (`{in,out}.3x.romashov.tech:443`)
+  - 1 × HTTPS check on `dash.romashov.tech` (basic-auth-fronted; 200 + 401
+    treated as reachable, since the TLS handshake itself is the signal)
+- **Slack contact point** using a Bot User OAuth Token (`xoxb-…`).
+- **Notification policy** routing everything labelled `origin=synthetic-monitoring`
+  to Slack, grouped by `alertname` + `target`.
+- **Alert rules** (one per check):
+  - `TCP/HTTPS probe down` — fires when `probe_success == 0` for 2 min from
+    all probes.
+  - `TLS cert expiring soon` — for HTTPS targets with `cert_expiry_warning=true`,
+    fires when fewer than `cert_expiry_warning_days` (default 14) remain.
+
+## Inputs
+
+Set in the root `terraform.tfvars` / via KV-derived env (`TF_VAR_…`):
+
+| Variable | Comes from |
+|---|---|
+| `grafana_cloud_api_key` | KV `grafana_cloud_api_key` — used as the `grafana` provider `auth` |
+| `grafana_synthetic_monitoring_token` | KV `GRAFANA_SYNTHETIC_MONITORING_TOKEN` — `sm_access_token` |
+| `slack_grafana_bot_token` | KV `slack_grafana_bot_token` — Slack app's `xoxb-…` |
+| `slack_grafana_alert_channel` | KV `slack_grafana_alert_channel` — channel name without `#` |
+
+## Adding a target
+
+Append to `tcp_targets` or `https_targets` in `variables.tf`. The check, alert
+rule, and Slack routing are generated from `for_each`, so no copy-paste.
+
+## Decommissioning Uptime Kuma
+
+After `terraform apply` and a verified end-to-end alert (manually break one
+probe target, watch Slack message), stop the container on node1:
+
+```bash
+cd /home/d.romashov/romashov-tech
+make stop-prod-monitoring
+```
+
+The Aiven MariaDB DB `monitoring` (used by Kuma) can be dropped via the
+`aiven-mysql` module once you're sure you don't want Kuma's historical data.

--- a/terraform/modules/grafana-monitoring/alerts.tf
+++ b/terraform/modules/grafana-monitoring/alerts.tf
@@ -1,0 +1,266 @@
+# ── Datasource lookup ──────────────────────────────────────────────────────
+# Grafana Cloud auto-provisions a Prometheus datasource with the stack slug
+# embedded ("grafanacloud-<slug>-prom"). Look it up to get the real UID.
+data "grafana_data_source" "prometheus" {
+  name = "grafanacloud-${var.stack_slug}-prom"
+}
+
+# ── Slack contact point ────────────────────────────────────────────────────
+resource "grafana_contact_point" "slack" {
+  name = "slack-${var.slack_channel}"
+
+  slack {
+    token     = var.slack_bot_token
+    recipient = var.slack_channel
+    title     = "{{ if eq .Status \"firing\" }}🔴{{ else }}✅{{ end }} {{ .CommonLabels.alertname }}"
+    text      = <<-EOT
+      {{ range .Alerts }}
+      *Status:* {{ .Status }}
+      *Target:* {{ .Labels.target }}
+      *Severity:* {{ .Labels.severity }}
+      *Summary:* {{ .Annotations.summary }}
+      {{ if .Annotations.runbook_url }}*Runbook:* {{ .Annotations.runbook_url }}{{ end }}
+      {{ end }}
+    EOT
+  }
+}
+
+# ── Notification policy ────────────────────────────────────────────────────
+# Singleton: configures the root policy for the stack. All synthetic-monitoring
+# alerts (matched by label origin=synthetic-monitoring set on each rule) route
+# to Slack; everything else falls through to whatever existed before.
+resource "grafana_notification_policy" "root" {
+  group_by      = ["alertname", "target"]
+  contact_point = grafana_contact_point.slack.name
+
+  group_wait      = "30s"
+  group_interval  = "5m"
+  repeat_interval = "4h"
+
+  policy {
+    contact_point = grafana_contact_point.slack.name
+    matcher {
+      label = "origin"
+      match = "="
+      value = "synthetic-monitoring"
+    }
+    group_by        = ["alertname", "target"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "4h"
+  }
+}
+
+# ── Folder ─────────────────────────────────────────────────────────────────
+resource "grafana_folder" "synthetic_monitoring" {
+  title = "Synthetic Monitoring Alerts"
+}
+
+# ── TCP probe-failure rules ────────────────────────────────────────────────
+resource "grafana_rule_group" "tcp_probe_down" {
+  name             = "tcp-probe-down"
+  folder_uid       = grafana_folder.synthetic_monitoring.uid
+  interval_seconds = 60
+
+  dynamic "rule" {
+    for_each = var.tcp_targets
+    content {
+      name           = "TCP probe down: ${rule.key}"
+      condition      = "B"
+      for            = "11m"
+      no_data_state  = "Alerting"
+      exec_err_state = "Alerting"
+
+      data {
+        ref_id         = "A"
+        datasource_uid = data.grafana_data_source.prometheus.uid
+        relative_time_range {
+          from = 300
+          to   = 0
+        }
+        model = jsonencode({
+          editorMode    = "code"
+          expr          = "min(probe_success{job=\"${rule.key}\"})"
+          intervalMs    = 1000
+          legendFormat  = "__auto"
+          maxDataPoints = 43200
+          range         = true
+          refId         = "A"
+        })
+      }
+
+      data {
+        ref_id         = "B"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 0
+          to   = 0
+        }
+        model = jsonencode({
+          conditions = [{
+            evaluator = { params = [1, 0], type = "lt" }
+            operator  = { type = "and" }
+            query     = { params = ["A"] }
+            reducer   = { params = [], type = "last" }
+            type      = "query"
+          }]
+          datasource    = { type = "__expr__", uid = "__expr__" }
+          expression    = "A"
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          refId         = "B"
+          type          = "classic_conditions"
+        })
+      }
+
+      labels = merge(rule.value.labels, {
+        severity = "critical"
+        origin   = "synthetic-monitoring"
+        target   = rule.value.target
+      })
+      annotations = {
+        summary = "TCP probe to ${rule.value.target} has failed for 11+ minutes from all configured probes"
+      }
+    }
+  }
+}
+
+# ── HTTPS probe-failure rules ──────────────────────────────────────────────
+resource "grafana_rule_group" "https_probe_down" {
+  name             = "https-probe-down"
+  folder_uid       = grafana_folder.synthetic_monitoring.uid
+  interval_seconds = 60
+
+  dynamic "rule" {
+    for_each = var.https_targets
+    content {
+      name           = "HTTPS probe down: ${rule.key}"
+      condition      = "B"
+      for            = "11m"
+      no_data_state  = "Alerting"
+      exec_err_state = "Alerting"
+
+      data {
+        ref_id         = "A"
+        datasource_uid = data.grafana_data_source.prometheus.uid
+        relative_time_range {
+          from = 300
+          to   = 0
+        }
+        model = jsonencode({
+          editorMode    = "code"
+          expr          = "min(probe_success{job=\"${rule.key}\"})"
+          intervalMs    = 1000
+          legendFormat  = "__auto"
+          maxDataPoints = 43200
+          range         = true
+          refId         = "A"
+        })
+      }
+
+      data {
+        ref_id         = "B"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 0
+          to   = 0
+        }
+        model = jsonencode({
+          conditions = [{
+            evaluator = { params = [1, 0], type = "lt" }
+            operator  = { type = "and" }
+            query     = { params = ["A"] }
+            reducer   = { params = [], type = "last" }
+            type      = "query"
+          }]
+          datasource    = { type = "__expr__", uid = "__expr__" }
+          expression    = "A"
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          refId         = "B"
+          type          = "classic_conditions"
+        })
+      }
+
+      labels = merge(rule.value.labels, {
+        severity = "critical"
+        origin   = "synthetic-monitoring"
+        target   = rule.value.target
+      })
+      annotations = {
+        summary = "HTTPS probe to ${rule.value.target} has failed for 11+ minutes from all configured probes"
+      }
+    }
+  }
+}
+
+# ── TLS cert-expiry rules ──────────────────────────────────────────────────
+# Only for https_targets with cert_expiry_warning=true. Preserves the intent
+# of Kuma's "Certificate" monitor type.
+resource "grafana_rule_group" "cert_expiring_soon" {
+  name             = "cert-expiring-soon"
+  folder_uid       = grafana_folder.synthetic_monitoring.uid
+  interval_seconds = 3600 # cert state changes slowly; hourly is enough
+
+  dynamic "rule" {
+    for_each = { for k, v in var.https_targets : k => v if v.cert_expiry_warning }
+    content {
+      name           = "TLS cert expiring soon: ${rule.key}"
+      condition      = "B"
+      for            = "1h"
+      no_data_state  = "NoData"
+      exec_err_state = "Alerting"
+
+      data {
+        ref_id         = "A"
+        datasource_uid = data.grafana_data_source.prometheus.uid
+        relative_time_range {
+          from = 600
+          to   = 0
+        }
+        model = jsonencode({
+          editorMode    = "code"
+          expr          = "(min(probe_ssl_earliest_cert_expiry{job=\"${rule.key}\"}) - time()) / 86400"
+          intervalMs    = 1000
+          legendFormat  = "days_remaining"
+          maxDataPoints = 43200
+          range         = true
+          refId         = "A"
+        })
+      }
+
+      data {
+        ref_id         = "B"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 0
+          to   = 0
+        }
+        model = jsonencode({
+          conditions = [{
+            evaluator = { params = [var.cert_expiry_warning_days, 0], type = "lt" }
+            operator  = { type = "and" }
+            query     = { params = ["A"] }
+            reducer   = { params = [], type = "last" }
+            type      = "query"
+          }]
+          datasource    = { type = "__expr__", uid = "__expr__" }
+          expression    = "A"
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          refId         = "B"
+          type          = "classic_conditions"
+        })
+      }
+
+      labels = merge(rule.value.labels, {
+        severity = "warning"
+        origin   = "synthetic-monitoring"
+        target   = rule.value.target
+      })
+      annotations = {
+        summary = "TLS cert for ${rule.value.target} expires in fewer than ${var.cert_expiry_warning_days} days"
+      }
+    }
+  }
+}

--- a/terraform/modules/grafana-monitoring/checks.tf
+++ b/terraform/modules/grafana-monitoring/checks.tf
@@ -1,0 +1,52 @@
+# Public probes published by Grafana Synthetic Monitoring. Names are
+# case-sensitive ("Frankfurt", not "frankfurt"). Lookup map by name → id.
+data "grafana_synthetic_monitoring_probes" "all" {}
+
+locals {
+  probe_ids = [for name in var.probes : data.grafana_synthetic_monitoring_probes.all.probes[name]]
+}
+
+resource "grafana_synthetic_monitoring_check" "tcp" {
+  for_each = var.tcp_targets
+
+  job     = each.key
+  target  = each.value.target
+  enabled = true
+  probes  = local.probe_ids
+  labels  = each.value.labels
+
+  frequency = var.check_frequency_seconds * 1000 # ms
+  timeout   = 10000
+
+  settings {
+    tcp {
+      ip_version = "Any"
+    }
+  }
+}
+
+resource "grafana_synthetic_monitoring_check" "https" {
+  for_each = var.https_targets
+
+  job     = each.key
+  target  = each.value.target
+  enabled = true
+  probes  = local.probe_ids
+  labels  = each.value.labels
+
+  frequency = var.check_frequency_seconds * 1000
+  timeout   = 10000
+
+  settings {
+    http {
+      ip_version          = "Any"
+      method              = "GET"
+      no_follow_redirects = false
+      valid_status_codes  = each.value.valid_status_codes
+
+      tls_config {
+        insecure_skip_verify = false
+      }
+    }
+  }
+}

--- a/terraform/modules/grafana-monitoring/dashboards.tf
+++ b/terraform/modules/grafana-monitoring/dashboards.tf
@@ -1,0 +1,23 @@
+# Public status page replacing Uptime Kuma's status/vpn. Dashboard JSON is a
+# template so we can inject the actual Prometheus datasource UID at render time.
+resource "grafana_dashboard" "vpn_status" {
+  config_json = templatefile("${path.module}/dashboards/vpn-status.json.tftpl", {
+    prometheus_uid = data.grafana_data_source.prometheus.uid
+  })
+  folder    = grafana_folder.synthetic_monitoring.uid
+  overwrite = true
+}
+
+# Public read-only link. anyone with the URL can view (no Grafana auth).
+resource "grafana_dashboard_public" "vpn_status" {
+  dashboard_uid = grafana_dashboard.vpn_status.uid
+  is_enabled    = true
+
+  # Time selection picker on a public dashboard is usually noise for a
+  # status page; the dashboard auto-refreshes every 5 min and is meant to
+  # show "now" status.
+  time_selection_enabled = false
+
+  # Annotations are admin-only context; don't leak them.
+  annotations_enabled = false
+}

--- a/terraform/modules/grafana-monitoring/dashboards/vpn-status.json.tftpl
+++ b/terraform/modules/grafana-monitoring/dashboards/vpn-status.json.tftpl
@@ -1,0 +1,240 @@
+{
+  "annotations": { "list": [] },
+  "description": "Public status page replacing Uptime Kuma's status/vpn",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "VLESS",
+      "type": "row"
+    },
+    {
+      "id": 1,
+      "type": "status-history",
+      "title": "VLESS endpoints",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+          "editorMode": "code",
+          "expr": "min by(job)(min_over_time(probe_success{job=~\"3x-ui-in|3x-ui-out\"}[10m]))",
+          "interval": "10m",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red", "index": 0 },
+                "1": { "text": "UP", "color": "green", "index": 1 }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 90,
+            "lineWidth": 0
+          }
+        }
+      },
+      "options": {
+        "colWidth": 0.95,
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "rowHeight": 0.85,
+        "showValue": "never",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "alignValue": "center"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "id": 101,
+      "panels": [],
+      "title": "Cisco Secure Connect / Cisco AnyConnect",
+      "type": "row"
+    },
+    {
+      "id": 2,
+      "type": "status-history",
+      "title": "Openconnect nodes",
+      "gridPos": { "h": 8, "w": 18, "x": 0, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+          "editorMode": "code",
+          "expr": "min by(job)(min_over_time(probe_success{job=~\"node[1-4]\"}[10m]))",
+          "interval": "10m",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red", "index": 0 },
+                "1": { "text": "UP", "color": "green", "index": 1 }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 90,
+            "lineWidth": 0
+          }
+        }
+      },
+      "options": {
+        "colWidth": 0.95,
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "rowHeight": 0.85,
+        "showValue": "never",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "alignValue": "center"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Certificate (dash.romashov.tech)",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+          "editorMode": "code",
+          "expr": "(min(probe_ssl_earliest_cert_expiry{job=\"dash\"}) - time()) / 86400",
+          "instant": true,
+          "legendFormat": "days remaining",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "d",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 7 },
+              { "color": "green", "value": 14 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "id": 102,
+      "panels": [],
+      "title": "Telegram",
+      "type": "row"
+    },
+    {
+      "id": 4,
+      "type": "status-history",
+      "title": "MTProxy (tg.romashov.tech)",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
+          "editorMode": "code",
+          "expr": "min by(job)(min_over_time(probe_success{job=\"mtproxy\"}[10m]))",
+          "interval": "10m",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red", "index": 0 },
+                "1": { "text": "UP", "color": "green", "index": 1 }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 90,
+            "lineWidth": 0
+          }
+        }
+      },
+      "options": {
+        "colWidth": 0.95,
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "rowHeight": 0.85,
+        "showValue": "never",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "alignValue": "center"
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["status-page", "synthetic-monitoring", "from-uptime-kuma"],
+  "templating": { "list": [] },
+  "time": { "from": "now-12h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "VPN инциденты",
+  "uid": "vpn-status",
+  "version": 1,
+  "weekStart": ""
+}

--- a/terraform/modules/grafana-monitoring/outputs.tf
+++ b/terraform/modules/grafana-monitoring/outputs.tf
@@ -1,0 +1,17 @@
+output "check_ids" {
+  description = "Map of SM check job name → check id"
+  value = merge(
+    { for k, c in grafana_synthetic_monitoring_check.tcp : k => c.id },
+    { for k, c in grafana_synthetic_monitoring_check.https : k => c.id },
+  )
+}
+
+output "slack_contact_point_name" {
+  description = "Name of the Slack contact point — useful if you wire up other policies elsewhere."
+  value       = grafana_contact_point.slack.name
+}
+
+output "public_status_page_url" {
+  description = "Public URL of the VPN status page (replaces Uptime Kuma's /status/vpn). Anyone with the link can view."
+  value       = "https://${var.stack_slug}.grafana.net/public-dashboards/${grafana_dashboard_public.vpn_status.access_token}"
+}

--- a/terraform/modules/grafana-monitoring/provider.tf
+++ b/terraform/modules/grafana-monitoring/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.14"
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3"
+    }
+  }
+}

--- a/terraform/modules/grafana-monitoring/variables.tf
+++ b/terraform/modules/grafana-monitoring/variables.tf
@@ -1,0 +1,91 @@
+variable "stack_slug" {
+  description = "Grafana Cloud stack slug — used to build the stack URL <slug>.grafana.net"
+  type        = string
+}
+
+variable "slack_bot_token" {
+  description = "Slack Bot User OAuth Token (xoxb-...) used by the Grafana Slack contact point"
+  type        = string
+  sensitive   = true
+}
+
+variable "slack_channel" {
+  description = "Slack channel (without #) the bot will post alerts to. Bot must be invited unless chat:write.public is granted."
+  type        = string
+}
+
+variable "probes" {
+  description = "Public probe names to schedule each check from. Stockholm = closest publicly-available probe to RU (no public probes exist inside Russia). Frankfurt = central-EU baseline. 8 checks × 2 probes × 10min ≈ 69k execs/month, fits the 100k free-tier quota with ~31k headroom (room for ~3 more checks at the same freq)."
+  type        = list(string)
+  default     = ["Stockholm", "Frankfurt"]
+}
+
+variable "check_frequency_seconds" {
+  description = "How often each check runs, in seconds. 600s (10 min) sized to leave quota headroom for adding more checks later — see comment on `probes`. Detection latency: probe miss + 11m for-clause + next probe ≈ 11-21 min."
+  type        = number
+  default     = 600
+}
+
+variable "tcp_targets" {
+  description = "TCP-port checks migrated from Uptime Kuma. Key becomes the SM job name."
+  type = map(object({
+    target = string
+    labels = map(string)
+  }))
+  default = {
+    node1 = {
+      target = "node1.romashov.tech:4443"
+      labels = { service = "openconnect", instance = "node1" }
+    }
+    node2 = {
+      target = "node2.romashov.tech:4443"
+      labels = { service = "openconnect", instance = "node2" }
+    }
+    node3 = {
+      target = "node3.romashov.tech:4443"
+      labels = { service = "openconnect", instance = "node3" }
+    }
+    node4 = {
+      target = "node4.romashov.tech:4443"
+      labels = { service = "openconnect", instance = "node4" }
+    }
+    "3x-ui-in" = {
+      target = "in.3x.romashov.tech:443"
+      labels = { service = "3x-ui-reality", direction = "in" }
+    }
+    "3x-ui-out" = {
+      target = "out.3x.romashov.tech:443"
+      labels = { service = "3x-ui-reality", direction = "out" }
+    }
+    mtproxy = {
+      target = "tg.romashov.tech:443"
+      labels = { service = "telegram-mtproxy" }
+    }
+  }
+}
+
+variable "https_targets" {
+  description = "HTTPS checks migrated from Uptime Kuma. dash is behind basic auth, so 401 is treated as 'reachable'."
+  type = map(object({
+    target              = string
+    valid_status_codes  = list(number)
+    labels              = map(string)
+    cert_expiry_warning = bool
+  }))
+  default = {
+    dash = {
+      target             = "https://dash.romashov.tech"
+      valid_status_codes = [200, 401]
+      labels             = { service = "traefik-dashboard" }
+      # Kuma's "Certificate" monitor existed specifically to alert on cert
+      # expiry — preserve that intent.
+      cert_expiry_warning = true
+    }
+  }
+}
+
+variable "cert_expiry_warning_days" {
+  description = "Fire a warning when probe_ssl_earliest_cert_expiry is closer than N days. Le certs are 90-day, so 14 days = ~16% remaining."
+  type        = number
+  default     = 14
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,8 @@ output "vpn_metrics_allowed_source_ip" {
   description = "Public IP sweden-node (Alloy)."
   value       = module.oci_vm.instance_public_ip
 }
+
+output "public_status_page_url" {
+  description = "Public URL of the VPN status page in Grafana Cloud (replaces monitoring.romashov.tech/status/vpn)."
+  value       = module.grafana_monitoring.public_status_page_url
+}

--- a/terraform/terraform.example.tfvars
+++ b/terraform/terraform.example.tfvars
@@ -17,3 +17,9 @@ mysql_monitoring_user_password = ""
 # OCI: VM и compartment захардкожены в модуле oci-vm и main.tf
 oci_private_key = ""
 
+# Grafana Cloud (modules/grafana-monitoring) — все значения из Cloudflare KV.
+# grafana_stack_slug дефолтится в "romashovtech" в variables.tf — переопредели
+# только если slug изменился.
+grafana_cloud_api_key              = "" # KV: grafana_cloud_api_key
+grafana_synthetic_monitoring_token = "" # KV: GRAFANA_SYNTHETIC_MONITORING_TOKEN
+slack_grafana_bot_token            = "" # KV: slack_grafana_bot_token

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,3 +83,28 @@ variable "oci_private_key" {
   type        = string
   sensitive   = true
 }
+
+# Grafana Cloud — used by modules/grafana-monitoring
+variable "grafana_stack_slug" {
+  description = "Grafana Cloud stack slug (the <slug>.grafana.net subdomain)"
+  type        = string
+  default     = "romashovtech"
+}
+
+variable "grafana_cloud_api_key" {
+  description = "Grafana Cloud Access Policy token with stacks:read + alerts:write + datasources:read scopes. Used as the grafana provider 'auth'."
+  type        = string
+  sensitive   = true
+}
+
+variable "grafana_synthetic_monitoring_token" {
+  description = "Grafana Synthetic Monitoring access token (generated in SM → Config after plugin install)."
+  type        = string
+  sensitive   = true
+}
+
+variable "slack_grafana_bot_token" {
+  description = "Slack Bot User OAuth Token (xoxb-...) for the Grafana Alerts custom Slack app."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- New `terraform/modules/grafana-monitoring/` provisions 8 Synthetic Monitoring checks (VPN openconnect + Reality + MTProxy + dash cert), alert rules routing to Slack `#general`, and a public status-page dashboard replicating Kuma's status/vpn layout
- Drops `monitoring.romashov.tech` A record, adds `status.romashov.tech` CNAME + Page Rule redirect to the Grafana Cloud public dashboard
- Removes `ansible/playbooks/deploy-monitoring.yml`, the `deploy-monitoring` make target, and the `monitoring` inventory group; the application repo PR ([framebassman/romashov-tech#TBD](https://github.com/framebassman/romashov-tech/pulls)) removes the compose file, Makefile targets, and the Traefik route in parallel

## Sizing notes

8 checks × 2 probes (Stockholm + Frankfurt) × 10-min frequency ≈ 69k execs/month → fits Grafana Cloud free-tier 100k quota with ~31k headroom for ~3 more checks at the same cadence. Detection latency: ~11–21 min (one missed probe cycle + 11m for-clause).

## CI caveat

`apply-terraform-modules` will run `terraform apply -auto-approve` on PR open. The local state already reflects every resource in this PR (applied during development), so it should be a no-op — **provided CI has the three new TF_VAR values populated**: `grafana_cloud_api_key`, `grafana_synthetic_monitoring_token`, `slack_grafana_bot_token`.

## Test plan

- [x] Resources already applied locally; Grafana Cloud shows 8 SM checks, 3 rule groups, contact point, public dashboard
- [x] Slack test message in #general from contact-point Test button — received
- [x] [Public dashboard](https://romashovtech.grafana.net/public-dashboards/25838dd671d042eb80ac110d30f096e1) rendering correctly with status-history timelines
- [ ] Verify CI tfvars contain the new variables before merge
- [ ] Stop Kuma container on node1 (`make stop-prod-monitoring`) before merging the sibling app-repo PR

This PR was created with AI assistance.