### PR TITLE
refactor(terraform): point status DNS at node2 traefik, drop CF page_rule

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,9 +36,8 @@ variable "account_id" { default = "4faf2c3b5dd13669f97dd976498ad56a" }
 provider "cloudflare" {}
 
 module "cloudflare" {
-  source              = "./modules/cloudflare/"
-  account_id          = var.account_id
-  status_redirect_url = module.grafana_monitoring.public_status_page_url
+  source     = "./modules/cloudflare/"
+  account_id = var.account_id
 }
 
 module "vdsina_ru" {

--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -50,34 +50,19 @@ resource "cloudflare_record" "a_in" {
   ttl     = 900
 }
 
-resource "cloudflare_record" "cname_status" {
+# status.romashov.tech → node2 (RU). Traefik on node2 reverse-proxies to
+# romashovtech.grafana.net (see services/proxy/config/dynamic/status.yml in
+# the application repo). Previously this was a proxied CNAME → grafana.net
+# plus a CF page_rule 302 to the dashboard URL; both were dropped because
+# RU clients couldn't follow the redirect (grafana.net unreachable on most
+# RU ISPs).
+resource "cloudflare_record" "a_status" {
   zone_id = local.zone_id
   name    = "status"
-  type    = "CNAME"
-  content = "romashovtech.grafana.net"
-  # Proxied so the page rule below can rewrite/redirect at CF edge. With
-  # proxied=false the browser would hit grafana.net directly with SNI=
-  # status.romashov.tech and get a cert mismatch (grafana's cert is *.grafana.net).
-  proxied = true
+  type    = "A"
+  content = "109.172.90.19"
+  proxied = false
   ttl     = 1
-}
-
-# 302 redirect: status.romashov.tech/* -> the full public-dashboard URL.
-# Required because Grafana Cloud doesn't support custom domains on Free/Pro
-# tiers (Enterprise only); the cleanest fallback for a vanity status URL is
-# an HTTP-level redirect at the CF edge.
-resource "cloudflare_page_rule" "status_redirect" {
-  zone_id  = local.zone_id
-  target   = "status.romashov.tech/*"
-  priority = 1
-  status   = "active"
-
-  actions {
-    forwarding_url {
-      url         = var.status_redirect_url
-      status_code = 302
-    }
-  }
 }
 
 resource "cloudflare_record" "a_node1" {

--- a/terraform/modules/cloudflare/variables.tf
+++ b/terraform/modules/cloudflare/variables.tf
@@ -2,8 +2,3 @@ variable "account_id" {
   description = "Cloudflare account ID"
   type        = string
 }
-
-variable "status_redirect_url" {
-  description = "Full URL the status.romashov.tech page rule redirects to (Grafana Cloud public dashboard). Comes from grafana-monitoring module output."
-  type        = string
-}


### PR DESCRIPTION
## Summary

- `status.romashov.tech` was a proxied CNAME → `romashovtech.grafana.net` plus a CF page_rule 302'ing to the public-dashboard URL. RU clients couldn't follow the redirect — `grafana.net` is intermittently unreachable on RU ISPs without a VPN.
- Reshape DNS so traefik on node2 fronts the hostname and reverse-proxies `grafana.net` upstream (route added in [framebassman/romashov-tech#350](https://github.com/framebassman/romashov-tech/pull/350), already merged & deployed per the precondition below):
  - Replace `cloudflare_record.cname_status` (CNAME, proxied) with `cloudflare_record.a_status` (A → `109.172.90.19`, unproxied) — same shape as `a_dash` / `a_in` / `a_out`.
  - Drop `cloudflare_page_rule.status_redirect`.
  - Drop the now-unused `status_redirect_url` variable and its wiring from `main.tf`.
- `module.grafana_monitoring.public_status_page_url` output stays at the root — admins can still pull the full dashboard URL via `terraform output public_status_page_url`.

## Precondition

App-side PR [framebassman/romashov-tech#350](https://github.com/framebassman/romashov-tech/pull/350) must be merged and `proxy-deploy` applied to node2 **before** opening this PR (CI here runs `terraform apply -auto-approve` on PR open). Otherwise `status.romashov.tech` 404s for the gap between DNS flip and traefik route landing.

Terraform plan was reviewed locally — three changes only: destroy `cname_status`, create `a_status`, destroy `page_rule`. No drift elsewhere.

## Test plan

- [ ] CI's `terraform apply -auto-approve` succeeds
- [ ] `dig +short status.romashov.tech` returns `109.172.90.19`
- [ ] `curl -sI https://status.romashov.tech/public-dashboards/<token>/` (token from `terraform output public_status_page_url`) returns 200
- [ ] Open from a RU connection without VPN — dashboard renders

This PR was created with AI assistance.