### PR TITLE
fix(ansible): drop compose down to let traefik hot-reload dynamic config

### DIFF
--- a/ansible/roles/romashov-tech-deployment/tasks/main.yml
+++ b/ansible/roles/romashov-tech-deployment/tasks/main.yml
@@ -43,11 +43,9 @@
     when: cloudflare_api_token is defined and cloudflare_api_token | length > 0
     no_log: true
 
-  - name: Stop Deployment
-    shell: "make stop-prod-{{ application }}"
-    args:
-      chdir: "{{ project_path }}"
-
+  # No `docker compose down` before `up -d`: avoids 5-15s outage on every deploy.
+  # Volume-mounted dynamic config changes hot-reload via the container's own watcher (e.g. traefik file provider).
+  # Real compose/image/env changes still recreate the container in place via `up -d`, but without the idle gap of `down`+`up`.
   - name: Start Deployment
     shell: "make start-prod-{{ application }}"
     args:


### PR DESCRIPTION
## Summary

- Problem: every proxy deploy currently runs `docker compose down` then `up -d`, causing a 5-15s outage on `status`, `dash`, `in`, `out`, `vault`, `white-list-check-api`, the `romashov.tech` apex, VLESS Reality on `:443` TCP, and openconnect on `:443` UDP, even when the only change is a hot-reloadable dynamic config file.
- Fix: drop the `Stop Deployment` ansible task; `docker compose up -d` is idempotent.
- Effect: no-op deploys (e.g. dynamic-config-only changes) cause no container restart and traefik hot-reloads via its file provider; real compose/image/env changes still recreate the container in place, but without the idle gap of `down`+`up`.

Closes #97

## Test plan

- [ ] `ansible-playbook --syntax-check` passes for all five `deploy-*.yml` playbooks that use the role
- [ ] CI's `apply-terraform-modules` shows no terraform drift (this PR doesn't touch `.tf` files)
- [ ] After merge, the next dynamic-config-only deploy in `romashov-tech` (e.g. a new `services/proxy/config/dynamic/*.yml`) is observably no-downtime: `docker inspect proxy --format '{{.State.StartedAt}}'` on node2 stays the same
- [ ] After merge, an actual recreate-needed deploy (compose/image bump) still works and serves traffic after restart

This PR was created with AI assistance.