### PR TITLE
chore(dashboard): translate status page labels to russian

### DIFF
--- a/terraform/modules/grafana-monitoring/dashboards/vpn-status.json.tftpl
+++ b/terraform/modules/grafana-monitoring/dashboards/vpn-status.json.tftpl
@@ -18,7 +18,7 @@
     {
       "id": 1,
       "type": "status-history",
-      "title": "VLESS endpoints",
+      "title": "VLESS сервера",
       "gridPos": { "h": 5, "w": 24, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
       "targets": [
@@ -77,7 +77,7 @@
     {
       "id": 2,
       "type": "status-history",
-      "title": "Openconnect nodes",
+      "title": "OpenConnect сервера",
       "gridPos": { "h": 8, "w": 18, "x": 0, "y": 7 },
       "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
       "targets": [
@@ -128,7 +128,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "Certificate (dash.romashov.tech)",
+      "title": "Сертификат (dash.romashov.tech)",
       "gridPos": { "h": 8, "w": 6, "x": 18, "y": 7 },
       "datasource": { "type": "prometheus", "uid": "${prometheus_uid}" },
       "targets": [
@@ -137,7 +137,7 @@
           "editorMode": "code",
           "expr": "(min(probe_ssl_earliest_cert_expiry{job=\"dash\"}) - time()) / 86400",
           "instant": true,
-          "legendFormat": "days remaining",
+          "legendFormat": "дней осталось",
           "range": false,
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

- `status.romashov.tech` audience is Russian-language; the VPN status dashboard had four English labels that the public sees.
- Translate the user-visible labels in `vpn-status.json.tftpl`:
  - `VLESS endpoints` → `VLESS сервера`
  - `Openconnect nodes` → `OpenConnect сервера`
  - `Certificate (dash.romashov.tech)` → `Сертификат (dash.romashov.tech)`
  - `days remaining` → `дней осталось`
- Product/proper-noun row titles (VLESS, Cisco Secure Connect / Cisco AnyConnect, Telegram, MTProxy) intentionally left in English. DOWN/UP status mappings kept — universally read.

## Effect

On merge, CI's `terraform apply -auto-approve` updates `grafana_dashboard.vpn_status` in Grafana Cloud in place (the `access_token` on the public dashboard does NOT rotate on dashboard JSON edits — verified previously with PR #98's no-op apply showing `25838dd...` unchanged). The public status page reflects the new labels within a refresh cycle.

## Test plan

- [ ] CI's `terraform plan` shows `1 to change` (the `grafana_dashboard.vpn_status` resource) and `0 to add / 0 to destroy`
- [ ] After apply, open `https://status.romashov.tech/public-dashboards/25838dd671d042eb80ac110d30f096e1/` — the three panel titles and the cert-stat legend are in Russian
- [ ] Public-dashboard URL still works (token unchanged)

This PR was created with AI assistance.