### PR TITLE
feat(vault): target sweden for deploy-vault, open OCI :443 ingress

### DIFF
--- a/ansible/playbooks/deploy-vault.yml
+++ b/ansible/playbooks/deploy-vault.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: russian
+- hosts: sweden
   become: true
   become_user: d.romashov
   vars:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,23 +131,24 @@ resource "oci_core_network_security_group_security_rule" "sweden_inbound_otlp_ht
   }
 }
 
-# Vault on sweden1 — terminates TLS itself with a Cloudflare Origin Certificate.
-# Cloudflare fronts vault.romashov.tech (proxied=true) and connects to the
-# origin on :443 in SSL mode "Full (Strict)". Locking to CF IP ranges would be
-# stricter but adds maintenance (CF rotates ranges); TLS + Vault auth are the
-# real access control. Open to 0.0.0.0/0.
-resource "oci_core_network_security_group_security_rule" "sweden_inbound_https_vault" {
+# Vault on sweden1 listens plain HTTP; Cloudflare fronts vault.romashov.tech
+# (proxied=true) and connects to the origin over HTTP in SSL mode "Flexible".
+# Client-facing TLS terminates at CF's edge with the Universal cert.
+# Trade-off: the CF→origin leg is plaintext over the public internet;
+# acceptable here because this Vault is a backup secret store (primary is
+# Cloudflare KV) and Vault's own auth is the real access control regardless.
+resource "oci_core_network_security_group_security_rule" "sweden_inbound_http_vault" {
   network_security_group_id = oci_core_network_security_group.sweden_inbound.id
   direction                 = "INGRESS"
   protocol                  = "6" # TCP
   source                    = "0.0.0.0/0"
   source_type               = "CIDR_BLOCK"
-  description               = "HTTPS for Vault (Cloudflare-fronted, TLS + Vault auth)"
+  description               = "HTTP for Vault (Cloudflare-fronted, Flexible SSL mode)"
 
   tcp_options {
     destination_port_range {
-      min = 443
-      max = 443
+      min = 80
+      max = 80
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,6 +131,27 @@ resource "oci_core_network_security_group_security_rule" "sweden_inbound_otlp_ht
   }
 }
 
+# Vault on sweden1 — terminates TLS itself with a Cloudflare Origin Certificate.
+# Cloudflare fronts vault.romashov.tech (proxied=true) and connects to the
+# origin on :443 in SSL mode "Full (Strict)". Locking to CF IP ranges would be
+# stricter but adds maintenance (CF rotates ranges); TLS + Vault auth are the
+# real access control. Open to 0.0.0.0/0.
+resource "oci_core_network_security_group_security_rule" "sweden_inbound_https_vault" {
+  network_security_group_id = oci_core_network_security_group.sweden_inbound.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "0.0.0.0/0"
+  source_type               = "CIDR_BLOCK"
+  description               = "HTTPS for Vault (Cloudflare-fronted, TLS + Vault auth)"
+
+  tcp_options {
+    destination_port_range {
+      min = 443
+      max = 443
+    }
+  }
+}
+
 # Бюджет $5 и алерт при достижении (для контроля расходов при PAYG)
 resource "oci_budget_budget" "monthly_limit" {
   compartment_id = var.oci_tenancy_ocid


### PR DESCRIPTION
## Summary

Infra-side half of the Vault move from node2 (RU) to sweden1 (OCI Stockholm). Paired with romashov-tech PR #353 which carries the application-side changes (compose/vault.json updates).

### Changes in this PR

- `ansible/playbooks/deploy-vault.yml`: `hosts: russian` → `hosts: sweden`.
- `terraform/main.tf`: new NSG rule on `sweden_inbound` allowing INGRESS TCP `:80` from `0.0.0.0/0`, for CF→origin traffic.

### What is NOT in this PR

- `cloudflare_record.a_vault` — still points at `109.172.90.19`. The DNS flip is intentionally deferred to a tiny follow-up PR that you open *after* manually verifying vault works on the direct sweden1 IP. That follow-up is what closes #101.
- App-side compose/config changes — those are in romashov-tech#353.

### CI safety

Opening this PR triggers `terraform apply -auto-approve`. Effects:

- NSG rule added — non-disruptive (no existing traffic on :80 to break).
- No `.tf` resource change that affects services currently in use.

`apply-infrastructure-playbook` runs but does not invoke `deploy-vault.yml`, so the role retargeting does not fire until the next real vault-deploy from romashov-tech#353.

### Merge order

Merge **this PR first**, then mark romashov-tech#353 ready-for-review and merge. Reverse order means `vault-deploy.yml` on app's master would deploy the new compose to node2 (old `hosts: russian`), which is bad.

Related to #101.

## Test plan

- [ ] CI `terraform plan` shows `1 to add` (the new NSG rule), no other changes.
- [ ] `terraform fmt -check` passes — verified locally.
- [ ] `ansible-playbook --syntax-check playbooks/deploy-vault.yml -i hosts.yml` passes.
- [ ] After the paired app PR is merged + cutover, `nc -zv 79.76.37.36 80` from a CF egress (or your laptop) reaches sweden1's vault.

This PR was created with AI assistance.