### PR TITLE
chore(cloudflare): flip vault DNS to sweden1, set zone SSL to Flexible

### DIFF
--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -159,9 +159,22 @@ resource "cloudflare_record" "a_vault" {
   zone_id = local.zone_id
   name    = "vault"
   type    = "A"
-  content = "109.172.90.19"
+  content = "79.76.37.36"
   proxied = true
   ttl     = 1
+}
+
+# Vault on sweden1 listens plain HTTP only. SSL mode "Flexible" tells
+# Cloudflare to terminate client TLS at the edge with its Universal cert
+# and connect to the origin over HTTP. This is zone-wide but safe: the only
+# externally-hosted proxied=true record in this zone is a_vault — the rest
+# (a_www dummy, cname_apex → Pages, cname_webhook → Tunnel) point at
+# CF-internal services where SSL mode is meaningless.
+resource "cloudflare_zone_settings_override" "romashov_tech" {
+  zone_id = local.zone_id
+  settings {
+    ssl = "flexible"
+  }
 }
 
 resource "cloudflare_record" "a_vpn" {


### PR DESCRIPTION
## Summary

Final cutover step for the Vault → sweden1 move. Two changes:

- \`cloudflare_record.a_vault.content\`: \`109.172.90.19\` → \`79.76.37.36\`.
- New \`cloudflare_zone_settings_override\` setting zone-wide SSL mode to **Flexible**. Vault on sweden1 listens plain HTTP only; CF terminates client-facing TLS at the edge.

Zone-wide SSL switch is safe here — \`a_vault\` is the only externally-hosted \`proxied=true\` record. The rest (\`a_www\` dummy, \`cname_apex\` → CF Pages, \`cname_webhook\` → CF Tunnel) target CF-internal services where the setting doesn't apply.

Closes #101.

## Test plan

- [ ] CI \`terraform plan\` shows: 1 change (a_vault content) + 1 add (zone_settings_override), no other drift.
- [ ] After apply: \`dig +short vault.romashov.tech\` resolves through CF (proxied IP).
- [ ] \`curl -sI https://vault.romashov.tech/v1/sys/health\` returns 200 if vault is unsealed OR 503 if sealed (both indicate CF→origin is working). Should NOT return 522/525 (those indicate SSL mode mismatch).

Vault is expected to be sealed after the migration; user will unseal at their convenience.

This PR was created with AI assistance.