### PR TITLE
chore(ansible): add acl to basic role for ansible become_user support

### DIFF
--- a/ansible/roles/basic/tasks/main.yml
+++ b/ansible/roles/basic/tasks/main.yml
@@ -10,6 +10,12 @@
       - curl
       - mc
       - make
+      # acl: lets ansible's become_user share temp files between unrelated
+      # users via POSIX ACLs (setfacl). Without it, `become: true,
+      # become_user: <non-root>` over an ubuntu-cloud SSH login fails with
+      # `chmod: invalid mode: 'A+user:...:rx:allow'`. Hit on the fresh OCI
+      # Ubuntu image (minimal — strips acl); vdsina hosts already had it.
+      - acl
 
   - name: Adding bashrc
     copy: src=../files/bash.bashrc dest=/etc/bash.bashrc


### PR DESCRIPTION
## Why

Ansible's `become: true, become_user: <non-root>` flow needs to share a temp file between two unrelated users (SSH login user → target user). The clean POSIX way is ACL — `setfacl` / `chmod A+user:...:rx:allow` — which requires the `acl` package.

OCI's Ubuntu cloud image is minimal and ships **without** `acl`. So when `deploy-vault.yml` ran against the freshly bootstrapped sweden1 (ansible SSHes as `ubuntu`, becomes `d.romashov`), it died with:

```
chmod: invalid mode: 'A+user:d.romashov:rx:allow'
```

Other inventory hosts (vdsina-provisioned) had `acl` installed from the start, so this never came up.

## Effect

Adding `acl` to the `basic` role's package list. The next `apply-infrastructure-playbook` run installs it on every host idempotently; on sweden it's the missing piece, on vdsina hosts it's a no-op.

## Test plan

- [ ] `apply-infrastructure-playbook` succeeds on PR open.
- [ ] After this PR merges, re-running the failed `vault-deploy.yml` (run 26344348450) succeeds — ansible can now become `d.romashov` on sweden.

## Related

- Issue #107 step 2 (sweden vault deploy) — this unblocks it.

This PR was created with AI assistance.