### PR TITLE
feat(3x-ui): xray-exporter firewall on :9091

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -26,6 +26,10 @@ deploy-3x-ui:
 	make requirements
 	ansible-playbook playbooks/deploy-3x-ui.yml
 
+3x-ui-metrics-firewall:
+	make requirements
+	ansible-playbook playbooks/3x-ui-metrics-firewall.yml
+
 deploy-grafana-alloy:
 	make requirements
 	ansible-playbook playbooks/deploy-grafana-alloy.yml \

--- a/ansible/playbooks/3x-ui-metrics-firewall-docker-user.service.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-docker-user.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restrict Docker port 9091 (xray-exporter) to Alloy IP (sweden-node)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/3x-ui-metrics-firewall-docker-user.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbooks/3x-ui-metrics-firewall-docker-user.sh.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-docker-user.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Restrict Docker-published port 9091 (xray-exporter) to Alloy IP only.
+# DOCKER-USER chain — same pattern as vpn-firewall-docker-user.sh (port 8000).
+set -e
+ALLOWED_IP="{{ xray_metrics_allowed_source_ip }}"
+PORT=9091
+if ! iptables -L DOCKER-USER -n &>/dev/null; then
+  echo "DOCKER-USER chain not found (Docker not running?). Skipping." >&2
+  exit 0
+fi
+iptables -C DOCKER-USER -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
+  iptables -I DOCKER-USER 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
+iptables -C DOCKER-USER -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
+  iptables -A DOCKER-USER -p tcp --dport "${PORT}" -j DROP

--- a/ansible/playbooks/3x-ui-metrics-firewall-host.service.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-host.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restrict host port 9091 (xray-exporter) to Alloy IP (sweden-node)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/3x-ui-metrics-firewall-host.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbooks/3x-ui-metrics-firewall-host.sh.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-host.sh.j2
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Restrict host port 9091 (xray-exporter, network_mode: host) to Alloy IP only.
+set -e
+ALLOWED_IP="{{ xray_metrics_allowed_source_ip }}"
+PORT=9091
+iptables -C INPUT -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
+  iptables -I INPUT 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
+iptables -C INPUT -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
+  iptables -A INPUT -p tcp --dport "${PORT}" -j DROP

--- a/ansible/playbooks/3x-ui-metrics-firewall.yml
+++ b/ansible/playbooks/3x-ui-metrics-firewall.yml
@@ -1,0 +1,81 @@
+---
+# Restrict xray-exporter (:9091) on 3x-ui nodes to Alloy (sweden) IP only.
+#   in  (Docker bridge): DOCKER-USER chain — same model as vpn-firewall.yml :8000
+#   out (host network):  iptables INPUT on the host
+#
+# Run: ansible-playbook -i hosts.yml playbooks/3x-ui-metrics-firewall.yml
+
+- hosts: _3xui
+  become: true
+  vars:
+    xray_metrics_allowed_source_ip: "{{ lookup('dig', groups['sweden'] | first) }}"
+  tasks:
+    - name: Fail if group sweden is missing in inventory
+      ansible.builtin.fail:
+        msg: "Inventory must define group sweden (Alloy host). Check hosts.yml."
+      when: groups['sweden'] | default([]) | length == 0
+
+    - name: Fail if Alloy IP could not be resolved
+      ansible.builtin.fail:
+        msg: "Could not resolve {{ groups['sweden'] | first }} to an IP for firewall rules."
+      when: xray_metrics_allowed_source_ip | length == 0
+
+    # ── in node (Docker) ─────────────────────────────────────────────────────
+    - name: Deploy DOCKER-USER script for port 9091 (in node)
+      ansible.builtin.template:
+        src: 3x-ui-metrics-firewall-docker-user.sh.j2
+        dest: /usr/local/bin/3x-ui-metrics-firewall-docker-user.sh
+        mode: "0755"
+      when: direction == 'in'
+
+    - name: Apply DOCKER-USER rules for port 9091 (in node)
+      ansible.builtin.command:
+        cmd: /usr/local/bin/3x-ui-metrics-firewall-docker-user.sh
+      register: docker_user_xray
+      changed_when: docker_user_xray.rc == 0
+      when: direction == 'in'
+
+    - name: Deploy systemd unit for DOCKER-USER xray metrics (in node)
+      ansible.builtin.template:
+        src: 3x-ui-metrics-firewall-docker-user.service.j2
+        dest: /etc/systemd/system/3x-ui-metrics-firewall-docker-user.service
+        mode: "0644"
+      when: direction == 'in'
+
+    - name: Enable 3x-ui-metrics-firewall-docker-user service (in node)
+      ansible.builtin.systemd:
+        name: 3x-ui-metrics-firewall-docker-user
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: direction == 'in'
+
+    # ── out node (host network) ────────────────────────────────────────────────
+    - name: Deploy host iptables script for port 9091 (out node)
+      ansible.builtin.template:
+        src: 3x-ui-metrics-firewall-host.sh.j2
+        dest: /usr/local/bin/3x-ui-metrics-firewall-host.sh
+        mode: "0755"
+      when: direction == 'out'
+
+    - name: Apply host iptables rules for port 9091 (out node)
+      ansible.builtin.command:
+        cmd: /usr/local/bin/3x-ui-metrics-firewall-host.sh
+      register: host_xray_fw
+      changed_when: host_xray_fw.rc == 0
+      when: direction == 'out'
+
+    - name: Deploy systemd unit for host xray metrics firewall (out node)
+      ansible.builtin.template:
+        src: 3x-ui-metrics-firewall-host.service.j2
+        dest: /etc/systemd/system/3x-ui-metrics-firewall-host.service
+        mode: "0644"
+      when: direction == 'out'
+
+    - name: Enable 3x-ui-metrics-firewall-host service (out node)
+      ansible.builtin.systemd:
+        name: 3x-ui-metrics-firewall-host
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: direction == 'out'


### PR DESCRIPTION
## Summary
- New playbook `3x-ui-metrics-firewall.yml` for `_3xui` hosts
- IN node (Docker): DOCKER-USER allow Alloy IP → :9091
- OUT node (host network): iptables INPUT allow Alloy IP → :9091
- Resolves Alloy IP via DNS from `groups['sweden']`

## Test plan
- [ ] `make 3x-ui-metrics-firewall` on both 3x-ui hosts
- [ ] Port 9091 reachable from Alloy, blocked from other IPs


Made with [Cursor](https://cursor.com)