### PR TITLE
feat(3x-ui): firewall rules for node_exporter port 9100

### DIFF
--- a/ansible/playbooks/3x-ui-metrics-firewall-docker-user.service.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-docker-user.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Restrict Docker port 9091 (xray-exporter) to Alloy IP (sweden-node)
+Description=Restrict Docker ports 9091/9100 (xray-exporter, node_exporter) to Alloy IP (sweden-node)
 After=docker.service
 Requires=docker.service
 

--- a/ansible/playbooks/3x-ui-metrics-firewall-docker-user.sh.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-docker-user.sh.j2
@@ -1,14 +1,16 @@
 #!/bin/bash
-# Restrict Docker-published port 9091 (xray-exporter) to Alloy IP only.
+# Restrict Docker-published ports 9091 (xray-exporter) and 9100 (node_exporter) to Alloy IP only.
 # DOCKER-USER chain — same pattern as vpn-firewall-docker-user.sh (port 8000).
 set -e
 ALLOWED_IP="{{ xray_metrics_allowed_source_ip }}"
-PORT=9091
+PORTS=(9091 9100)
 if ! iptables -L DOCKER-USER -n &>/dev/null; then
   echo "DOCKER-USER chain not found (Docker not running?). Skipping." >&2
   exit 0
 fi
-iptables -C DOCKER-USER -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
-  iptables -I DOCKER-USER 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
-iptables -C DOCKER-USER -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
-  iptables -A DOCKER-USER -p tcp --dport "${PORT}" -j DROP
+for PORT in "${PORTS[@]}"; do
+  iptables -C DOCKER-USER -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
+    iptables -I DOCKER-USER 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
+  iptables -C DOCKER-USER -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
+    iptables -A DOCKER-USER -p tcp --dport "${PORT}" -j DROP
+done

--- a/ansible/playbooks/3x-ui-metrics-firewall-host.service.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-host.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Restrict host port 9091 (xray-exporter) to Alloy IP (sweden-node)
+Description=Restrict host ports 9091/9100 (xray-exporter, node_exporter) to Alloy IP (sweden-node)
 After=network-online.target
 Wants=network-online.target
 

--- a/ansible/playbooks/3x-ui-metrics-firewall-host.sh.j2
+++ b/ansible/playbooks/3x-ui-metrics-firewall-host.sh.j2
@@ -1,9 +1,11 @@
 #!/bin/bash
-# Restrict host port 9091 (xray-exporter, network_mode: host) to Alloy IP only.
+# Restrict host ports 9091 (xray-exporter) and 9100 (node_exporter, network_mode: host) to Alloy IP only.
 set -e
 ALLOWED_IP="{{ xray_metrics_allowed_source_ip }}"
-PORT=9091
-iptables -C INPUT -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
-  iptables -I INPUT 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
-iptables -C INPUT -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
-  iptables -A INPUT -p tcp --dport "${PORT}" -j DROP
+PORTS=(9091 9100)
+for PORT in "${PORTS[@]}"; do
+  iptables -C INPUT -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT 2>/dev/null || \
+    iptables -I INPUT 1 -s "${ALLOWED_IP}" -p tcp --dport "${PORT}" -j ACCEPT
+  iptables -C INPUT -p tcp --dport "${PORT}" -j DROP 2>/dev/null || \
+    iptables -A INPUT -p tcp --dport "${PORT}" -j DROP
+done

--- a/ansible/playbooks/3x-ui-metrics-firewall.yml
+++ b/ansible/playbooks/3x-ui-metrics-firewall.yml
@@ -1,5 +1,5 @@
 ---
-# Restrict xray-exporter (:9091) on 3x-ui nodes to Alloy (sweden) IP only.
+# Restrict xray-exporter (:9091) and node_exporter (:9100) on 3x-ui nodes to Alloy (sweden) IP only.
 #   in  (Docker bridge): DOCKER-USER chain — same model as vpn-firewall.yml :8000
 #   out (host network):  iptables INPUT on the host
 #


### PR DESCRIPTION
## Summary
- Extend `3x-ui-metrics-firewall` scripts to restrict port **9100** (node_exporter) alongside existing **9091** (xray-exporter)
- DOCKER-USER chain on in node, iptables INPUT on out node — same Alloy IP allowlist

Part of framebassman/romashov-tech#367 (Variant B).

## Test plan
- [ ] `ansible-playbook playbooks/3x-ui-metrics-firewall.yml` on both _3xui hosts
- [ ] Port 9100 blocked from public, allowed from sweden/Alloy IP


Made with [Cursor](https://cursor.com)