### PR TITLE
feat(terraform): add public R2 bucket with custom domain

### DIFF
--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -10,11 +10,6 @@ resource "cloudflare_r2_bucket" "vpn_certs" {
   name       = "vpn-certs"
 }
 
-import {
-  to = cloudflare_r2_bucket.public
-  id = "4faf2c3b5dd13669f97dd976498ad56a/public"
-}
-
 resource "cloudflare_r2_bucket" "public" {
   account_id = var.account_id
   name       = "public"

--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -10,6 +10,20 @@ resource "cloudflare_r2_bucket" "vpn_certs" {
   name       = "vpn-certs"
 }
 
+resource "cloudflare_r2_bucket" "public" {
+  account_id = var.account_id
+  name       = "public"
+}
+
+resource "cloudflare_r2_custom_domain" "public" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.public.name
+  domain      = "public.romashov.tech"
+  zone_id     = local.zone_id
+  enabled     = true
+  min_tls     = "1.2"
+}
+
 # Terraform remote state backend — do not delete
 resource "cloudflare_r2_bucket" "terraform_backend" {
   account_id = var.account_id

--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -10,6 +10,11 @@ resource "cloudflare_r2_bucket" "vpn_certs" {
   name       = "vpn-certs"
 }
 
+import {
+  to = cloudflare_r2_bucket.public
+  id = "4faf2c3b5dd13669f97dd976498ad56a/public"
+}
+
 resource "cloudflare_r2_bucket" "public" {
   account_id = var.account_id
   name       = "public"


### PR DESCRIPTION
## Summary

- Adds `cloudflare_r2_bucket` named `public`
- Adds `cloudflare_r2_custom_domain` serving it at `public.romashov.tech` (TLS 1.2+, enabled)
- Cloudflare manages the DNS CNAME and TLS cert automatically — no manual DNS record needed
- VPN certs will be stored at `public/vpn-certs/<username>/` going forward

## Test plan

- [ ] `terraform plan` shows only the two new resources (bucket + custom domain)
- [ ] After apply: `https://public.romashov.tech` resolves and returns objects from the bucket
- [ ] SSL cert status in Cloudflare dashboard shows `active`

> ⚠️ Note: the infra CI runs `terraform apply -auto-approve` on every PR. This will create the R2 bucket and custom domain immediately on merge.

This PR was created with AI assistance.