### PR TITLE
feat(terraform): vpn-certs R2 bucket with managed domain + Traefik DNS

### DIFF
--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -1,5 +1,14 @@
 # ── A records ────────────────────────────────────────────────────────────────
 
+resource "cloudflare_dns_record" "a_certs" {
+  zone_id = local.zone_id
+  name    = "certs"
+  type    = "A"
+  content = "109.172.90.19"
+  proxied = false
+  ttl     = 1
+}
+
 resource "cloudflare_dns_record" "a_alloy" {
   zone_id = local.zone_id
   name    = "alloy"

--- a/terraform/modules/cloudflare/provider.tf
+++ b/terraform/modules/cloudflare/provider.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/external"
       version = "~> 2"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3"
+    }
   }
 }
 

--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -10,6 +10,29 @@ resource "cloudflare_r2_bucket" "vpn_certs" {
   name       = "vpn-certs"
 }
 
+resource "cloudflare_r2_managed_domain" "vpn_certs" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.vpn_certs.name
+  enabled     = true
+}
+
+# Writes the computed r2.dev domain to KV so fetch-secrets.sh can render
+# services/proxy/config/dynamic/vpn-certs.yml on the host at deploy time.
+resource "null_resource" "vpn_certs_r2_domain_to_kv" {
+  triggers = {
+    domain = cloudflare_r2_managed_domain.vpn_certs.domain
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -sf -X PUT \
+        "https://api.cloudflare.com/client/v4/accounts/${var.account_id}/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/VPN_CERTS_R2_DEV_DOMAIN" \
+        -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+        --data-binary "${cloudflare_r2_managed_domain.vpn_certs.domain}"
+    EOT
+  }
+}
+
 resource "cloudflare_r2_bucket" "public" {
   account_id = var.account_id
   name       = "public"


### PR DESCRIPTION
## Summary

- Recreates `vpn-certs` R2 bucket (deleted manually from CF dashboard)
- Adds `cloudflare_r2_managed_domain` → generates obscure `pub-<hash>.r2.dev` URL
- Writes the computed domain to KV key `VPN_CERTS_R2_DEV_DOMAIN` via `null_resource` local-exec
- Adds DNS A record `certs.romashov.tech → 109.172.90.19` (node2, Traefik)
- Adds `null` provider to cloudflare module

## After apply — one-time manual setup

1. Upload htpasswd entry to KV:
   ```
   htpasswd -nb <user> <password>
   # then upload the result:
   wrangler kv key put VPN_CERTS_BASIC_AUTH_HTPASSWD "<user>:<hash>" --namespace-id f0b474a7601c4e16bf88e3e290db5602
   ```
2. Add GitHub secrets to romashov-tech repo:
   - `VPN_CERTS_BASIC_AUTH_USER` — plain text username
   - `VPN_CERTS_BASIC_AUTH_PASS` — plain text password (same as used in htpasswd)
3. Run `make fetch-secrets` on node2 to render `vpn-certs.yml`, then `make start-prod-proxy`

## Architecture

```
user → certs.romashov.tech (Traefik, basicauth) → pub-<hash>.r2.dev (R2 vpn-certs bucket)
```

The r2.dev URL is obscure (Cloudflare-generated hash) and not committed anywhere.

This PR was created with AI assistance.