### PR TITLE
refactor(terraform): rename vpn-certs subdomain to account ID prefix

### DIFF
--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -2,7 +2,7 @@
 
 resource "cloudflare_dns_record" "a_certs" {
   zone_id = local.zone_id
-  name    = "certs"
+  name    = "4faf2c3b5dd13669f97dd976498ad56a"
   type    = "A"
   content = "109.172.90.19"
   proxied = false


### PR DESCRIPTION
## Summary

Renames DNS record for the VPN certs Traefik proxy:

- `certs.romashov.tech` → `4faf2c3b5dd13669f97dd976498ad56a.romashov.tech`

The subdomain now matches the Cloudflare account ID pattern, making it harder to guess than a semantic name like `certs`.

## After apply

Run `make fetch-secrets && make start-prod-proxy` on node2 to reload Traefik with the updated hostname.

This PR was created with AI assistance.