### PR TITLE
feat(ansible): automate wildcard cert sync from Traefik to VPN nodes via R2

### DIFF
--- a/.github/workflows/cert-sync.yml
+++ b/.github/workflows/cert-sync.yml
@@ -1,0 +1,24 @@
+name: Sync VPN wildcard cert to R2
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'  # 04:00 UTC every Monday
+
+jobs:
+  cert-sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Run cert-sync playbook
+        uses: dawidd6/action-ansible-playbook@v9
+        with:
+          directory: ./ansible
+          playbook: ./playbooks/cert-sync.yml
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          requirements: ./requirements.yml
+          options: |
+            --extra-vars CLOUDFLARE_R2_API_KEY_ID=${{ secrets.CLOUDFLARE_R2_API_KEY_ID }}
+            --extra-vars CLOUDFLARE_R2_API_ACCESS_SECRET=${{ secrets.CLOUDFLARE_R2_API_ACCESS_SECRET }}
+            --extra-vars CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/ansible/playbooks/cert-sync.yml
+++ b/ansible/playbooks/cert-sync.yml
@@ -1,0 +1,21 @@
+- hosts: russian
+  become: true
+  become_user: d.romashov
+  vars:
+    project_path: /home/d.romashov/romashov-tech
+  tasks:
+    - name: Upload cert to R2
+      ansible.builtin.include_role:
+        name: cert-sync
+        tasks_from: upload.yml
+
+- hosts: vpn
+  become: true
+  become_user: d.romashov
+  vars:
+    project_path: /home/d.romashov/romashov-tech
+  tasks:
+    - name: Pull cert from R2
+      ansible.builtin.include_role:
+        name: cert-sync
+        tasks_from: pull.yml

--- a/ansible/roles/cert-sync/tasks/pull.yml
+++ b/ansible/roles/cert-sync/tasks/pull.yml
@@ -1,0 +1,52 @@
+---
+- name: Set R2 endpoint
+  ansible.builtin.set_fact:
+    r2_endpoint: "https://{{ CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+
+- name: Download cert from R2
+  amazon.aws.s3_object:
+    mode: get
+    bucket: vpn-certs
+    object: cert.pem
+    dest: /tmp/vpn-cert-sync.crt
+    endpoint_url: "{{ r2_endpoint }}"
+    access_key: "{{ CLOUDFLARE_R2_API_KEY_ID }}"
+    secret_key: "{{ CLOUDFLARE_R2_API_ACCESS_SECRET }}"
+    region: us-east-1
+
+- name: Download key from R2
+  amazon.aws.s3_object:
+    mode: get
+    bucket: vpn-certs
+    object: key.pem
+    dest: /tmp/vpn-cert-sync.key
+    endpoint_url: "{{ r2_endpoint }}"
+    access_key: "{{ CLOUDFLARE_R2_API_KEY_ID }}"
+    secret_key: "{{ CLOUDFLARE_R2_API_ACCESS_SECRET }}"
+    region: us-east-1
+  no_log: true
+
+# ansible.builtin.copy with remote_src compares checksums — only writes if changed,
+# which prevents spurious ocserv reloads on unchanged certs
+- name: Install cert (ocserv auto-reloads on file change)
+  ansible.builtin.copy:
+    src: /tmp/vpn-cert-sync.crt
+    dest: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-crt.pem"
+    mode: "0644"
+    remote_src: true
+
+- name: Install key
+  ansible.builtin.copy:
+    src: /tmp/vpn-cert-sync.key
+    dest: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-key.pem"
+    mode: "0600"
+    remote_src: true
+  no_log: true
+
+- name: Remove temp files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/vpn-cert-sync.crt
+    - /tmp/vpn-cert-sync.key

--- a/ansible/roles/cert-sync/tasks/upload.yml
+++ b/ansible/roles/cert-sync/tasks/upload.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify R2 credentials are provided
+  ansible.builtin.assert:
+    that:
+      - CLOUDFLARE_R2_API_KEY_ID is defined and CLOUDFLARE_R2_API_KEY_ID | length > 0
+      - CLOUDFLARE_R2_API_ACCESS_SECRET is defined and CLOUDFLARE_R2_API_ACCESS_SECRET | length > 0
+      - CLOUDFLARE_ACCOUNT_ID is defined and CLOUDFLARE_ACCOUNT_ID | length > 0
+    fail_msg: >-
+      Missing R2 credentials. Pass via --extra-vars
+      CLOUDFLARE_R2_API_KEY_ID / CLOUDFLARE_R2_API_ACCESS_SECRET / CLOUDFLARE_ACCOUNT_ID.
+    quiet: true
+  delegate_to: localhost
+  run_once: true
+
+- name: Set R2 endpoint
+  ansible.builtin.set_fact:
+    r2_endpoint: "https://{{ CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+
+- name: Extract cert and key from acme.json into letsencrypt dir
+  ansible.builtin.shell: |
+    jq -r '.leresolver.Certificates[] | select(.domain.main=="romashov.tech") | .certificate' \
+      {{ project_path }}/services/proxy/certs/acme.json \
+    | base64 -d > "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-crt.pem"
+    jq -r '.leresolver.Certificates[] | select(.domain.main=="romashov.tech") | .key' \
+      {{ project_path }}/services/proxy/certs/acme.json \
+    | base64 -d > "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-key.pem"
+  changed_when: true
+  no_log: true
+
+- name: Upload cert to R2
+  amazon.aws.s3_object:
+    mode: put
+    bucket: vpn-certs
+    object: cert.pem
+    src: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-crt.pem"
+    endpoint_url: "{{ r2_endpoint }}"
+    access_key: "{{ CLOUDFLARE_R2_API_KEY_ID }}"
+    secret_key: "{{ CLOUDFLARE_R2_API_ACCESS_SECRET }}"
+    region: us-east-1
+    permission: []
+
+- name: Upload key to R2
+  amazon.aws.s3_object:
+    mode: put
+    bucket: vpn-certs
+    object: key.pem
+    src: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-key.pem"
+    endpoint_url: "{{ r2_endpoint }}"
+    access_key: "{{ CLOUDFLARE_R2_API_KEY_ID }}"
+    secret_key: "{{ CLOUDFLARE_R2_API_ACCESS_SECRET }}"
+    region: us-east-1
+    permission: []
+  no_log: true


### PR DESCRIPTION
## Summary

- New Ansible role `cert-sync` with `upload.yml` (node2) and `pull.yml` (all VPN nodes)
- New playbook `cert-sync.yml` — two sequential plays: upload on `russian` group first, then pull on `vpn` group
- New GitHub Actions workflow — runs every Monday at 04:00 UTC, same secrets as `backup-3x.yml`

## How it works

**Play 1 → `hosts: russian` (node2)**
Extracts `*.romashov.tech` cert and key from Traefik's `acme.json` via `jq`, writes to `services/openconnect/letsencrypt/`, uploads to R2 bucket `vpn-certs` using `amazon.aws.s3_object`.

**Play 2 → `hosts: vpn` (node1 + node2)**
Downloads cert/key from R2 to each node. `ansible.builtin.copy` is idempotent — only writes if checksum differs, so ocserv reloads only when cert actually changed.

**Why weekly:** Traefik renews at 30 days before expiry (day 60 of a 90-day cert). A 60-day sync interval risks a race where cert-sync runs before renewal, pushing a cert with 30 days left and missing the next sync window. Weekly ensures nodes get the renewed cert within 7 days of Traefik's renewal — worst case 83 days of validity remaining.

**Reuses backup pattern:** `amazon.aws.s3_object` + `CLOUDFLARE_R2_API_KEY_ID` / `CLOUDFLARE_R2_API_ACCESS_SECRET` / `CLOUDFLARE_ACCOUNT_ID` from GitHub secrets, same as `backup-3x-ui.yml`.

## Test plan

- [ ] Run `workflow_dispatch` manually after merge
- [ ] Verify cert files updated in `services/openconnect/letsencrypt/` on both nodes
- [ ] Verify ocserv picks up new cert (check `docker logs openconnect` for reload message)

This PR was created with AI assistance.