### PR TITLE
feat(cert-sync): run cert-sync as a deploy pre-step

### DIFF
--- a/ansible/playbooks/deploy-proxy.yml
+++ b/ansible/playbooks/deploy-proxy.yml
@@ -5,5 +5,19 @@
   vars:
     application: proxy
     project_path: "/home/d.romashov/romashov-tech"
+  # Snapshot Traefik's current wildcard cert to R2 BEFORE the deployment role runs.
+  # This runs before `git reset --hard`, so the live cert is captured even on the
+  # deploy that drops acme.json from the repo. Skipped on a fresh host where Traefik
+  # has not issued a cert yet (no acme.json to extract from).
+  pre_tasks:
+    - name: Stat acme.json
+      ansible.builtin.stat:
+        path: "{{ project_path }}/services/proxy/certs/acme.json"
+      register: acme_json
+    - name: Upload server cert to R2 from acme.json
+      ansible.builtin.import_role:
+        name: cert-sync
+        tasks_from: upload.yml
+      when: acme_json.stat.exists and (acme_json.stat.size | default(0) | int) > 2
   roles:
   - romashov-tech-deployment

--- a/ansible/playbooks/deploy-vpn.yml
+++ b/ansible/playbooks/deploy-vpn.yml
@@ -5,5 +5,12 @@
   vars:
     application: vpn
     project_path: "/home/d.romashov/romashov-tech"
+  # Pull the server cert from R2 BEFORE the deployment role runs `make start`, so the
+  # bind-mount source (outside the repo working tree) exists when ocserv starts.
+  pre_tasks:
+    - name: Sync ocserv server cert from R2
+      ansible.builtin.import_role:
+        name: cert-sync
+        tasks_from: pull.yml
   roles:
   - romashov-tech-deployment

--- a/ansible/roles/cert-sync/tasks/pull.yml
+++ b/ansible/roles/cert-sync/tasks/pull.yml
@@ -3,6 +3,19 @@
   ansible.builtin.set_fact:
     r2_endpoint: "https://{{ CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
+# Certs are installed OUTSIDE the repo working tree so the deployment role's
+# `git reset --hard` can never delete them. Must match the bind-mount source in
+# romashov-tech/deploy/docker-compose.vpn.yml (VPN_CERTS_DIR, same default).
+- name: Set VPN certs dir
+  ansible.builtin.set_fact:
+    vpn_certs_dir: "{{ vpn_certs_dir | default('/home/d.romashov/vpn-certs') }}"
+
+- name: Ensure VPN certs dir exists
+  ansible.builtin.file:
+    path: "{{ vpn_certs_dir }}"
+    state: directory
+    mode: "0700"
+
 - name: Download cert from R2
   amazon.aws.s3_object:
     mode: get
@@ -31,14 +44,14 @@
 - name: Install cert (ocserv auto-reloads on file change)
   ansible.builtin.copy:
     src: /tmp/vpn-cert-sync.crt
-    dest: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-crt.pem"
+    dest: "{{ vpn_certs_dir }}/server-cert.pem"
     mode: "0644"
     remote_src: true
 
 - name: Install key
   ansible.builtin.copy:
     src: /tmp/vpn-cert-sync.key
-    dest: "{{ project_path }}/services/openconnect/letsencrypt/*.romashov.tech-key.pem"
+    dest: "{{ vpn_certs_dir }}/server-key.pem"
     mode: "0600"
     remote_src: true
   no_log: true


### PR DESCRIPTION
## What

Wire the `cert-sync` role into the regular deploy path (not just the weekly cron), so the `*.romashov.tech` TLS material is provisioned on hosts at deploy time and no longer needs to live in git.

- **deploy-vpn**: `pre_task` pulls the ocserv server cert from R2 **before** the deployment role runs `make start`, so the (now out-of-repo) bind-mount source exists when ocserv starts.
- **deploy-proxy**: `pre_task` uploads Traefik's current wildcard cert to R2 **before** `git reset --hard`, capturing the live cert even on the deploy that drops `acme.json` from the repo. Skipped on a fresh host with no `acme.json` yet.
- **pull.yml**: installs the cert into an out-of-repo dir (`vpn_certs_dir`, default `/home/d.romashov/vpn-certs`) matching the new compose bind-mount, so `git reset --hard` can't delete it.

## Pairs with

`framebassman/romashov-tech#418` (app repo — untrack acme.json + .pem, out-of-repo mount, CI R2 creds). **Merge this PR first**: the app deploy workflows check out infra master at runtime, so `cert-sync pull` must be on master before the app's new mount goes live.

## ⚠️ CI side effects on open

Opening this PR triggers `deploy.yml` (`terraform apply -auto-approve` + `infrastructure.yml` + `vpn-firewall.yml`) against real cloud/hosts. The cert-sync deploy-vpn/deploy-proxy changes themselves run later via the app repo's deploy workflows.

## Requires

GitHub secrets already used by `cert-sync.yml`: `CLOUDFLARE_R2_API_KEY_ID`, `CLOUDFLARE_R2_API_ACCESS_SECRET`, `CLOUDFLARE_ACCOUNT_ID` (also added to the app repo's deploy steps).

## Verification
- `ansible-playbook --syntax-check` on both playbooks → OK
- YAML parse of playbooks + pull.yml → OK

This PR was created with AI assistance.