### PR TITLE
feat(cert-sync): install certs into services/openconnect/letsencrypt

### DIFF
--- a/ansible/roles/cert-sync/tasks/pull.yml
+++ b/ansible/roles/cert-sync/tasks/pull.yml
@@ -3,12 +3,12 @@
   ansible.builtin.set_fact:
     r2_endpoint: "https://{{ CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
-# Certs are installed OUTSIDE the repo working tree so the deployment role's
-# `git reset --hard` can never delete them. Must match the bind-mount source in
-# romashov-tech/deploy/docker-compose.vpn.yml (VPN_CERTS_DIR, same default).
+# Certs land inside the repo tree at services/openconnect/letsencrypt/.
+# Files are listed in .gitignore so git reset --hard during deploy won't touch them.
+# Must match the bind-mount source in romashov-tech/deploy/docker-compose.vpn.yml.
 - name: Set VPN certs dir
   ansible.builtin.set_fact:
-    vpn_certs_dir: "{{ vpn_certs_dir | default('/home/d.romashov/vpn-certs') }}"
+    vpn_certs_dir: "{{ vpn_certs_dir | default('/home/d.romashov/romashov-tech/services/openconnect/letsencrypt') }}"
 
 - name: Ensure VPN certs dir exists
   ansible.builtin.file:
@@ -44,14 +44,14 @@
 - name: Install cert (ocserv auto-reloads on file change)
   ansible.builtin.copy:
     src: /tmp/vpn-cert-sync.crt
-    dest: "{{ vpn_certs_dir }}/server-cert.pem"
+    dest: "{{ vpn_certs_dir }}/*.romashov.tech-crt.pem"
     mode: "0644"
     remote_src: true
 
 - name: Install key
   ansible.builtin.copy:
     src: /tmp/vpn-cert-sync.key
-    dest: "{{ vpn_certs_dir }}/server-key.pem"
+    dest: "{{ vpn_certs_dir }}/*.romashov.tech-key.pem"
     mode: "0600"
     remote_src: true
   no_log: true


### PR DESCRIPTION
## Summary

- Update `vpn_certs_dir` default from `/home/d.romashov/vpn-certs` to `/home/d.romashov/romashov-tech/services/openconnect/letsencrypt`
- Rename install destinations from `server-cert.pem` / `server-key.pem` to `*.romashov.tech-crt.pem` / `*.romashov.tech-key.pem`
- Update comment: files are now inside the repo tree but protected by `.gitignore`

Companion PR in `romashov-tech` updates the bind-mount paths in the compose files.

## Test plan

- [ ] Deploy with `ansible-playbook --check deploy-vpn.yml` to verify task targets
- [ ] After merge: run `deploy-vpn.yml` and confirm cert lands at new path and ocserv picks it up

This PR was created with AI assistance.