### PR TITLE
chore(terraform): rename D1 database resource to romashov-tech

### DIFF
--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -74,9 +74,9 @@ data "external" "slack_grafana_bot_token" {
 
 # ── D1 Databases ─────────────────────────────────────────────────────────────
 
-resource "cloudflare_d1_database" "romashov_tech_status_incidents" {
+resource "cloudflare_d1_database" "romashov_tech" {
   account_id = var.account_id
-  name       = "romashov-tech-status-incidents"
+  name       = "romashov-tech"
   read_replication = {
     mode = "disabled"
   }


### PR DESCRIPTION
## Summary

- `storage.tf`: ресурс переименован `cloudflare_d1_database.romashov_tech_status_incidents` → `cloudflare_d1_database.romashov_tech`, `name` → `romashov-tech`

## ⚠️ ОБЯЗАТЕЛЬНО до открытия/мержа этого PR

CI запускает `terraform apply -auto-approve` на каждый PR. Без ручной подготовки Terraform уничтожит существующую базу с данными.

**Шаги:**

1. Переименовать базу в **Cloudflare Dashboard**: Workers & Pages → D1 → `romashov-tech-status-incidents` → Rename → `romashov-tech`
2. Локально:
   ```bash
   terraform state rm 'module.cloudflare.cloudflare_d1_database.romashov_tech_status_incidents'
   terraform import 'module.cloudflare.cloudflare_d1_database.romashov_tech' \
     '4faf2c3b5dd13669f97dd976498ad56a/7faf79bc-c671-4a00-8fb6-24ba147ee634'
   terraform plan  # должно показать: No changes
   ```
3. Только после этого открывать PR (или убедиться что CI не отработал деструктивно).

## Парный PR

https://github.com/framebassman/romashov-tech/pull/432 (wrangler + workflow)

## Test plan

- [ ] Переименовать базу в Cloudflare Dashboard
- [ ] `terraform state rm` + `terraform import` + `terraform plan` → No changes
- [ ] Открыть PR → CI apply не затрагивает D1
- [ ] Смержить после парного PR в romashov-tech

This PR was created with AI assistance.