### PR TITLE
feat(terraform): add D1 database romashov-tech

### DIFF
--- a/terraform/modules/cloudflare/outputs.tf
+++ b/terraform/modules/cloudflare/outputs.tf
@@ -8,3 +8,8 @@ output "slack_grafana_bot_token" {
   value       = data.external.slack_grafana_bot_token.result.value
   sensitive   = true
 }
+
+output "d1_romashov_tech_database_id" {
+  description = "UUID новой D1 базы romashov-tech — нужен для wrangler.toml после миграции данных"
+  value       = cloudflare_d1_database.romashov_tech.id
+}

--- a/terraform/modules/cloudflare/storage.tf
+++ b/terraform/modules/cloudflare/storage.tf
@@ -81,3 +81,11 @@ resource "cloudflare_d1_database" "romashov_tech_status_incidents" {
     mode = "disabled"
   }
 }
+
+resource "cloudflare_d1_database" "romashov_tech" {
+  account_id = var.account_id
+  name       = "romashov-tech"
+  read_replication = {
+    mode = "disabled"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,3 +12,8 @@ output "public_status_page_url" {
   description = "Public URL of the VPN status page in Grafana Cloud (replaces monitoring.romashov.tech/status/vpn)."
   value       = module.grafana_monitoring.public_status_page_url
 }
+
+output "d1_romashov_tech_database_id" {
+  description = "UUID новой D1 базы romashov-tech — подставить в wrangler.toml после копирования данных"
+  value       = module.cloudflare.d1_romashov_tech_database_id
+}


### PR DESCRIPTION
## Summary

Phase 1 миграции: создать новую D1 базу `romashov-tech` рядом со старой `romashov-tech-status-incidents`.

- `storage.tf`: добавлен новый ресурс `cloudflare_d1_database.romashov_tech` (старый не тронут)
- `modules/cloudflare/outputs.tf` + `outputs.tf`: добавлен output `d1_romashov_tech_database_id`

После мержа и CI apply — UUID новой базы будет виден в `terraform output d1_romashov_tech_database_id`.

## Порядок действий после мержа

```bash
# 1. Получить UUID новой базы
terraform output d1_romashov_tech_database_id

# 2. Скопировать данные (в директории romashov-tech/services/status/)
wrangler d1 export romashov-tech-status-incidents --remote --output old_db_backup.sql
wrangler d1 execute romashov-tech --remote --file old_db_backup.sql

# 3. Проверить данные в новой базе
wrangler d1 execute romashov-tech --remote --command "SELECT * FROM incidents LIMIT 10;"

# 4. Создать PR в romashov-tech с новым database_id в wrangler.toml → переключить приложение
# 5. После деплоя — создать PR для удаления старой базы
```

## Test plan

- [ ] CI apply создал новую D1 базу
- [ ] `terraform output d1_romashov_tech_database_id` возвращает UUID
- [ ] Данные скопированы и проверены в новой базе
- [ ] Созданы follow-up PR-ы (переключение приложения + удаление старой DB)

This PR was created with AI assistance.