### PR TITLE
fix(terraform): correct out.3x.romashov.tech DNS A record

### DIFF
--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -97,7 +97,7 @@ resource "cloudflare_dns_record" "a_out_3x" {
   zone_id = local.zone_id
   name    = "out.3x"
   type    = "A"
-  content = "91.239.206.123"
+  content = "206.168.215.160"
   proxied = false
   ttl     = 900
 }


### PR DESCRIPTION
## Summary

- `out.3x.romashov.tech` was pointing to `91.239.206.123` (stale/wrong IP)
- `out.romashov.tech` panel showed Nginx Proxy Manager default page because Traefik proxied to that wrong host
- Fixed to `206.168.215.160` — the actual out-node IP (matches `ansible/hosts.yml`)

## Test plan

- [ ] PR CI runs `terraform apply` — verify plan shows only the one DNS record update
- [ ] After merge, confirm `dig +short out.3x.romashov.tech` returns `206.168.215.160`
- [ ] Open `https://out.romashov.tech` — should show 3x-ui panel (with auth prompt)

This PR was created with AI assistance.