### PR TITLE
feat(lubelog): ansible role, terraform DB + DNS

### DIFF
--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ansible/roles/lubelog/**
+      - ansible/playbooks/deploy-lubelog.yml
+      - .github/workflows/lubelog-deploy.yml
+  workflow_dispatch:
+
+name: lubelog-deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Deploy lubelog
+        uses: dawidd6/action-ansible-playbook@v9
+        with:
+          directory: ./ansible
+          playbook: ./playbooks/deploy-lubelog.yml
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          requirements: requirements.yml
+          options: |
+            --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -27,6 +27,11 @@ deploy-3x-ui:
 	make requirements
 	ansible-playbook playbooks/deploy-3x-ui.yml
 
+deploy-lubelog:
+	make requirements
+	ansible-playbook playbooks/deploy-lubelog.yml \
+		--extra-vars "lubelog_db_url=$${LUBELOG_DB_URL}"
+
 3x-ui-metrics-firewall:
 	make requirements
 	ansible-playbook playbooks/3x-ui-metrics-firewall.yml

--- a/ansible/playbooks/deploy-lubelog.yml
+++ b/ansible/playbooks/deploy-lubelog.yml
@@ -1,0 +1,6 @@
+---
+- hosts: georgia
+  become: true
+  become_user: d.romashov
+  roles:
+    - lubelog

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  lubelog:
+    image: ghcr.io/hargata/lubelog:latest
+    container_name: lubelog
+    ports:
+      - "8000:8080"
+    env_file:
+      - .env
+    volumes:
+      - lubelog_data:/App/data
+    restart: unless-stopped
+
+volumes:
+  lubelog_data:
+    name: lubelog_data

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create lubelog working directory
+  ansible.builtin.file:
+    path: /home/d.romashov/lubelog
+    state: directory
+    owner: d.romashov
+    mode: '0750'
+
+- name: Copy docker-compose file
+  ansible.builtin.copy:
+    src: docker-compose.yml
+    dest: /home/d.romashov/lubelog/docker-compose.yml
+    owner: d.romashov
+    mode: '0640'
+
+- name: Write .env file
+  ansible.builtin.copy:
+    content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url }}\n"
+    dest: /home/d.romashov/lubelog/.env
+    owner: d.romashov
+    mode: '0600'
+  no_log: true
+
+- name: Pull latest lubelog image and start container
+  ansible.builtin.shell: docker compose -f /home/d.romashov/lubelog/docker-compose.yml pull && docker compose -f /home/d.romashov/lubelog/docker-compose.yml up -d
+  args:
+    chdir: /home/d.romashov/lubelog
+
+- name: Remove unused docker images
+  ansible.builtin.shell: docker image prune --all --force

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,6 +60,7 @@ module "aiven" {
   pg_outline_user_password   = data.external.pg_outline_user_password.result.value
   pg_vault_user_password     = data.external.pg_vault_user_password.result.value
   pg_mtproxy_user_password   = data.external.pg_mtproxy_user_password.result.value
+  pg_lubelog_user_password   = data.external.pg_lubelog_user_password.result.value
 }
 
 # OCI: аутентификация из переменных (terraform.tfvars или backend.conf)
@@ -119,6 +120,13 @@ data "external" "pg_mtproxy_user_password" {
   program = [
     "bash", "-c",
     "curl -sf -H \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \"${local.kv_base_url}/pg_mtproxy_user_password\" | jq -Rc '{value: .}'"
+  ]
+}
+
+data "external" "pg_lubelog_user_password" {
+  program = [
+    "bash", "-c",
+    "curl -sf -H \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \"${local.kv_base_url}/pg_lubelog_user_password\" | jq -Rc '{value: .}'"
   ]
 }
 

--- a/terraform/modules/aiven/postgres.tf
+++ b/terraform/modules/aiven/postgres.tf
@@ -86,6 +86,39 @@ resource "aiven_pg_user" "mtproxy_user" {
   pg_allow_replication = false
 }
 
+resource "aiven_pg_database" "lubelog" {
+  project       = aiven_pg.this.project
+  service_name  = aiven_pg.this.service_name
+  database_name = "lubelog_db"
+}
+
+resource "aiven_pg_user" "lubelog_user" {
+  project              = aiven_pg.this.project
+  service_name         = aiven_pg.this.service_name
+  username             = "lubelog-user"
+  password             = var.pg_lubelog_user_password
+  pg_allow_replication = false
+}
+
+resource "null_resource" "lubelog_grants" {
+  depends_on = [
+    aiven_pg_database.lubelog,
+    aiven_pg_user.lubelog_user,
+  ]
+  triggers = {
+    db   = aiven_pg_database.lubelog.database_name
+    user = aiven_pg_user.lubelog_user.username
+  }
+  provisioner "local-exec" {
+    environment = {
+      PGCONN_POSTGRES = replace(aiven_pg.this.service_uri, "defaultdb", "postgres")
+      PGCONN_LUBELOG  = replace(aiven_pg.this.service_uri, "defaultdb", "lubelog_db")
+    }
+    command     = "psql \"$PGCONN_POSTGRES\" -v ON_ERROR_STOP=1 -c 'GRANT CONNECT, CREATE ON DATABASE \"lubelog_db\" TO \"lubelog-user\";' && psql \"$PGCONN_LUBELOG\" -v ON_ERROR_STOP=1 -c 'GRANT USAGE, CREATE ON SCHEMA public TO \"lubelog-user\";'"
+    interpreter = ["bash", "-c"]
+  }
+}
+
 # Права пользователя mtproxy-production на БД mtproxy-production (CONNECT + CREATE на БД и схему public).
 # Выполняется через psql под avnadmin (service_uri), т.к. Aiven не даёт выдать права через Terraform provider.
 resource "null_resource" "mtproxy_grants" {

--- a/terraform/modules/aiven/variables.tf
+++ b/terraform/modules/aiven/variables.tf
@@ -37,3 +37,8 @@ variable "pg_mtproxy_user_password" {
   description = "Password for Postgres mtproxy-production user (MTProxy secrets DB)"
   type        = string
 }
+
+variable "pg_lubelog_user_password" {
+  description = "Password for Postgres lubelog-user"
+  type        = string
+}

--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -27,6 +27,16 @@ resource "cloudflare_dns_record" "a_dash" {
   ttl     = 1
 }
 
+# lube.romashov.tech → node2 (RU). Traefik reverse-proxies to ge node (91.239.206.123:18333).
+resource "cloudflare_dns_record" "a_lube" {
+  zone_id = local.zone_id
+  name    = "lube"
+  type    = "A"
+  content = "109.172.90.19"
+  proxied = false
+  ttl     = 1
+}
+
 resource "cloudflare_dns_record" "a_in_3x" {
   zone_id = local.zone_id
   name    = "in.3x"


### PR DESCRIPTION
## Summary

- `ansible/roles/lubelog/`: custom role that copies `docker-compose.yml` to the ge node (`georgia` inventory group), writes `.env` with the Aiven connection string, pulls image, runs `docker compose up -d`
- `ansible/roles/lubelog/files/docker-compose.yml`: lubelog container on `8000:8080`, named volume `lubelog_data`
- `ansible/playbooks/deploy-lubelog.yml`: targets `georgia` group
- `ansible/Makefile`: `deploy-lubelog` target
- `terraform/modules/aiven/postgres.tf`: `lubelog_db` database + `lubelog-user` + grants
- `terraform/modules/aiven/variables.tf`: `pg_lubelog_user_password` variable
- `terraform/main.tf`: data source (fetches password from Cloudflare KV key `pg_lubelog_user_password`) + module argument
- `terraform/modules/cloudflare/dns.tf`: `lube.romashov.tech` A → `109.172.90.19` (Traefik on node2)
- `.github/workflows/lubelog-deploy.yml`: triggers on ansible role/playbook changes, deploys to ge node

## Prerequisites before merging

1. Add Aiven DB password to Cloudflare KV:
   ```
   make upload-secret KEY=pg_lubelog_user_password VALUE=<password>
   ```
2. Add `LUBELOG_DB_URL` GitHub Secret to **both** repos (full Aiven connection string):
   ```
   Host=<aiven-host>;Port=<port>;Database=lubelog_db;Username=lubelog-user;Password=<password>;SslMode=Require
   ```
3. Ensure ge node has the GitHub deploy key (`~/.ssh/github_actions_id_rsa`) — not required for this role since it doesn't clone the app repo, but Docker must be accessible to `d.romashov`

## Test plan

- [ ] `terraform plan` output shows `lubelog_db` database, `lubelog-user`, grants, and DNS record — no unintended changes
- [ ] `ansible-playbook --check playbooks/deploy-lubelog.yml` passes
- [ ] After merge: terraform apply creates DB + user + `lube.romashov.tech` DNS record
- [ ] After merge: CI deploys lubelog container to ge node, accessible at `91.239.206.123:8000`

This PR was created with AI assistance.