### PR TITLE
fix(lubelog): run as root, deploy to /opt/lubelog

### DIFF
--- a/ansible/playbooks/deploy-lubelog.yml
+++ b/ansible/playbooks/deploy-lubelog.yml
@@ -1,6 +1,4 @@
 ---
 - hosts: georgia
-  become: true
-  become_user: d.romashov
   roles:
     - lubelog

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -1,30 +1,27 @@
 ---
 - name: Create lubelog working directory
   ansible.builtin.file:
-    path: /home/d.romashov/lubelog
+    path: /opt/lubelog
     state: directory
-    owner: d.romashov
     mode: '0750'
 
 - name: Copy docker-compose file
   ansible.builtin.copy:
     src: docker-compose.yml
-    dest: /home/d.romashov/lubelog/docker-compose.yml
-    owner: d.romashov
+    dest: /opt/lubelog/docker-compose.yml
     mode: '0640'
 
 - name: Write .env file
   ansible.builtin.copy:
     content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url }}\n"
-    dest: /home/d.romashov/lubelog/.env
-    owner: d.romashov
+    dest: /opt/lubelog/.env
     mode: '0600'
   no_log: true
 
 - name: Pull latest lubelog image and start container
-  ansible.builtin.shell: docker compose -f /home/d.romashov/lubelog/docker-compose.yml pull && docker compose -f /home/d.romashov/lubelog/docker-compose.yml up -d
+  ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
-    chdir: /home/d.romashov/lubelog
+    chdir: /opt/lubelog
 
 - name: Remove unused docker images
   ansible.builtin.shell: docker image prune --all --force


### PR DESCRIPTION
## Problem

`remote_user = root` in `ansible.cfg` means ansible connects as root. The playbook had `become: true, become_user: d.romashov`, which caused ansible to try creating `/home/d.romashov/lubelog` as d.romashov — but the home directory on the ge node isn't writable by d.romashov (Permission denied).

## Fix

- Remove `become` from `deploy-lubelog.yml` — tasks run as root directly
- Change deploy directory from `/home/d.romashov/lubelog` → `/opt/lubelog`
- Remove `owner: d.romashov` from file tasks

## Test plan

- [ ] Re-run `lubelog-deploy` workflow after merge
- [ ] `docker ps` on ge node shows `lubelog` container running on port 8000

This PR was created with AI assistance.