### PR TITLE
fix(lubelog): use Docker Hub image instead of GHCR

### DIFF
--- a/ansible/playbooks/deploy-lubelog.yml
+++ b/ansible/playbooks/deploy-lubelog.yml
@@ -1,6 +1,4 @@
 ---
 - hosts: georgia
-  become: true
-  become_user: d.romashov
   roles:
     - lubelog

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lubelog:
-    image: ghcr.io/hargata/lubelog:latest
+    image: hargata/lubelog:latest
     container_name: lubelog
     ports:
       - "8000:8080"

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -1,30 +1,27 @@
 ---
 - name: Create lubelog working directory
   ansible.builtin.file:
-    path: /home/d.romashov/lubelog
+    path: /opt/lubelog
     state: directory
-    owner: d.romashov
     mode: '0750'
 
 - name: Copy docker-compose file
   ansible.builtin.copy:
     src: docker-compose.yml
-    dest: /home/d.romashov/lubelog/docker-compose.yml
-    owner: d.romashov
+    dest: /opt/lubelog/docker-compose.yml
     mode: '0640'
 
 - name: Write .env file
   ansible.builtin.copy:
     content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url }}\n"
-    dest: /home/d.romashov/lubelog/.env
-    owner: d.romashov
+    dest: /opt/lubelog/.env
     mode: '0600'
   no_log: true
 
 - name: Pull latest lubelog image and start container
-  ansible.builtin.shell: docker compose -f /home/d.romashov/lubelog/docker-compose.yml pull && docker compose -f /home/d.romashov/lubelog/docker-compose.yml up -d
+  ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
-    chdir: /home/d.romashov/lubelog
+    chdir: /opt/lubelog
 
 - name: Remove unused docker images
   ansible.builtin.shell: docker image prune --all --force


### PR DESCRIPTION
## Problem

`ghcr.io/hargata/lubelog:latest` returns `denied` on the ge node — GHCR package is either private or the node has no GHCR auth token.

## Fix

Switch to `hargata/lubelog:latest` (Docker Hub) which is publicly accessible without authentication.

This PR was created with AI assistance.