### PR TITLE
fix(lubelog): pin image to v1.6.7, remove GHCR auth

### DIFF
--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -25,5 +25,3 @@ jobs:
           requirements: requirements.yml
           options: |
             --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"
-            --extra-vars "ghcr_token=${{ secrets.GHCR_TOKEN }}"
-            --extra-vars "ghcr_username=${{ secrets.GHCR_USERNAME }}"

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -30,9 +30,7 @@ deploy-3x-ui:
 deploy-lubelog:
 	make requirements
 	ansible-playbook playbooks/deploy-lubelog.yml \
-		--extra-vars "lubelog_db_url=$${LUBELOG_DB_URL}" \
-		--extra-vars "ghcr_token=$${GHCR_TOKEN}" \
-		--extra-vars "ghcr_username=$${GHCR_USERNAME}"
+		--extra-vars "lubelog_db_url=$${LUBELOG_DB_URL}"
 
 3x-ui-metrics-firewall:
 	make requirements

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lubelog:
-    image: hargata/lubelog:latest
+    image: ghcr.io/hargata/lubelog:v1.6.7
     container_name: lubelog
     ports:
       - "8000:8080"

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -18,11 +18,7 @@
     mode: '0600'
   no_log: true
 
-- name: Login to GHCR
-  ansible.builtin.shell: echo "{{ ghcr_token }}" | docker login ghcr.io -u "{{ ghcr_username }}" --password-stdin
-  no_log: true
-
-- name: Pull latest lubelog image and start container
+- name: Pull lubelog image and start container
   ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
     chdir: /opt/lubelog


### PR DESCRIPTION
latest tag does not exist on ghcr.io/hargata/lubelog. Pin to v1.6.7 (current latest release) — publicly accessible without auth. Remove docker login task and GHCR secrets.