### PR TITLE
fix(lubelog): authenticate to GHCR before pulling image

### DIFF
--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -25,3 +25,5 @@ jobs:
           requirements: requirements.yml
           options: |
             --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"
+            --extra-vars "ghcr_token=${{ secrets.GHCR_TOKEN }}"
+            --extra-vars "ghcr_username=${{ secrets.GHCR_USERNAME }}"

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -18,10 +18,18 @@
     mode: '0600'
   no_log: true
 
+- name: Log in to GHCR
+  ansible.builtin.shell: >
+    echo "{{ ghcr_token }}" | docker login ghcr.io --username "{{ ghcr_username }}" --password-stdin
+  no_log: true
+
 - name: Pull lubelog image and start container
   ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
     chdir: /opt/lubelog
+
+- name: Log out of GHCR
+  ansible.builtin.shell: docker logout ghcr.io
 
 - name: Remove unused docker images
   ansible.builtin.shell: docker image prune --all --force


### PR DESCRIPTION
## Summary

- Adds `docker login ghcr.io` before pulling the lubelog image in the Ansible role
- Adds `docker logout ghcr.io` after the pull to clean up credentials
- Passes `GHCR_TOKEN` and `GHCR_USERNAME` from GitHub secrets as Ansible extra-vars

## Why

GHCR requires authentication even for publicly visible packages — anonymous pulls are denied with `error from registry: denied`. The ge node has no Docker credentials for `ghcr.io`, so every deploy was failing on the pull step.

## Before merging — add two secrets to this repo

Go to **Settings → Secrets → Actions** in `romashov-tech-infrastructure` and add:

| Name | Value |
|------|-------|
| `GHCR_TOKEN` | A GitHub PAT with **`read:packages`** scope (classic token works fine) |
| `GHCR_USERNAME` | The GitHub username that owns the PAT (e.g. `framebassman`) |

The PAT only needs `read:packages` — no write access required.

## Test plan

- [ ] Add `GHCR_TOKEN` and `GHCR_USERNAME` secrets to the repo
- [ ] Merge this PR → `lubelog-deploy` workflow triggers
- [ ] Workflow run succeeds; `lube.romashov.tech` responds with 401 (auth prompt)

This PR was created with AI assistance.