### PR TITLE
fix(lubelog): clear stale GHCR credentials before image pull

### DIFF
--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -25,3 +25,5 @@ jobs:
           requirements: requirements.yml
           options: |
             --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"
+            --extra-vars "ghcr_token=${{ secrets.GHCR_TOKEN }}"
+            --extra-vars "ghcr_username=${{ secrets.GHCR_USERNAME }}"

--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -25,5 +25,3 @@ jobs:
           requirements: requirements.yml
           options: |
             --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"
-            --extra-vars "ghcr_token=${{ secrets.GHCR_TOKEN }}"
-            --extra-vars "ghcr_username=${{ secrets.GHCR_USERNAME }}"

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -18,10 +18,18 @@
     mode: '0600'
   no_log: true
 
+- name: Log in to GHCR
+  ansible.builtin.shell: >
+    echo "{{ ghcr_token }}" | docker login ghcr.io --username "{{ ghcr_username }}" --password-stdin
+  no_log: true
+
 - name: Pull lubelog image and start container
   ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
     chdir: /opt/lubelog
+
+- name: Log out of GHCR
+  ansible.builtin.shell: docker logout ghcr.io
 
 - name: Remove unused docker images
   ansible.builtin.shell: docker image prune --all --force

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -18,18 +18,14 @@
     mode: '0600'
   no_log: true
 
-- name: Log in to GHCR
-  ansible.builtin.shell: >
-    echo "{{ ghcr_token }}" | docker login ghcr.io --username "{{ ghcr_username }}" --password-stdin
-  no_log: true
+- name: Clear stale GHCR credentials
+  ansible.builtin.shell: docker logout ghcr.io
+  failed_when: false
 
 - name: Pull lubelog image and start container
   ansible.builtin.shell: docker compose pull && docker compose up -d
   args:
     chdir: /opt/lubelog
-
-- name: Log out of GHCR
-  ansible.builtin.shell: docker logout ghcr.io
 
 - name: Remove unused docker images
   ansible.builtin.shell: docker image prune --all --force


### PR DESCRIPTION
## Summary

- Adds `docker logout ghcr.io` (with `failed_when: false`) before the pull step in the lubelog Ansible role

## Root cause

An earlier deploy attempt ran `docker login ghcr.io` with empty/invalid credentials, leaving a stale entry in `/root/.docker/config.json` on the ge node. Docker sends those credentials on every subsequent pull; GHCR responds `denied` instead of allowing the anonymous pull. The image is public — it doesn't require auth.

## Fix

`docker logout ghcr.io` before the pull removes the stale entry, so Docker falls back to an anonymous pull which works for the public image. `failed_when: false` ensures the task doesn't break if there are no credentials to clear.

## Test plan

- [ ] Merge → `lubelog-deploy` triggers automatically
- [ ] Pull step succeeds; `lube.romashov.tech` is accessible

This PR was created with AI assistance.