### PR TITLE
feat(lubelog): fix image name, KV for db url, community.docker modules

### DIFF
--- a/.github/workflows/lubelog-deploy.yml
+++ b/.github/workflows/lubelog-deploy.yml
@@ -24,4 +24,4 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           requirements: requirements.yml
           options: |
-            --extra-vars "lubelog_db_url=${{ secrets.LUBELOG_DB_URL }}"
+            --extra-vars "cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}"

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   lubelog:
-    image: ghcr.io/hargata/lubelog:v1.6.7
+    image: ghcr.io/hargata/lubelogger:v1.6.7
     container_name: lubelog
     ports:
-      - "8000:8080"
+      - 8000:8080
     env_file:
       - .env
     volumes:
@@ -12,4 +12,3 @@ services:
 
 volumes:
   lubelog_data:
-    name: lubelog_data

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Fetch lubelog DB URL from Cloudflare KV
   ansible.builtin.uri:
-    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/lubelog_db_url"
+    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/LUBELOG_DB_URL"
     headers:
       Authorization: "Bearer {{ cloudflare_api_token }}"
     return_content: true

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -11,21 +11,31 @@
     dest: /opt/lubelog/docker-compose.yml
     mode: '0640'
 
+- name: Fetch lubelog DB URL from Cloudflare KV
+  ansible.builtin.uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/lubelog_db_url"
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+    return_content: true
+    status_code: 200
+  register: lubelog_db_url_result
+  no_log: true
+
 - name: Write .env file
   ansible.builtin.copy:
-    content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url }}\n"
+    content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}\n"
     dest: /opt/lubelog/.env
     mode: '0600'
   no_log: true
 
-- name: Clear stale GHCR credentials
-  ansible.builtin.shell: docker logout ghcr.io
-  failed_when: false
-
-- name: Pull lubelog image and start container
-  ansible.builtin.shell: docker compose pull && docker compose up -d
-  args:
-    chdir: /opt/lubelog
+- name: Deploy lubelog
+  community.docker.docker_compose_v2:
+    project_src: /opt/lubelog
+    pull: always
+    state: present
 
 - name: Remove unused docker images
-  ansible.builtin.shell: docker image prune --all --force
+  community.docker.docker_prune:
+    images: true
+    images_filters:
+      dangling: false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,7 +60,6 @@ module "aiven" {
   pg_outline_user_password   = data.external.pg_outline_user_password.result.value
   pg_vault_user_password     = data.external.pg_vault_user_password.result.value
   pg_mtproxy_user_password   = data.external.pg_mtproxy_user_password.result.value
-  pg_lubelog_user_password   = data.external.pg_lubelog_user_password.result.value
 }
 
 # OCI: аутентификация из переменных (terraform.tfvars или backend.conf)
@@ -120,13 +119,6 @@ data "external" "pg_mtproxy_user_password" {
   program = [
     "bash", "-c",
     "curl -sf -H \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \"${local.kv_base_url}/pg_mtproxy_user_password\" | jq -Rc '{value: .}'"
-  ]
-}
-
-data "external" "pg_lubelog_user_password" {
-  program = [
-    "bash", "-c",
-    "curl -sf -H \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \"${local.kv_base_url}/pg_lubelog_user_password\" | jq -Rc '{value: .}'"
   ]
 }
 

--- a/terraform/modules/aiven/postgres.tf
+++ b/terraform/modules/aiven/postgres.tf
@@ -96,8 +96,11 @@ resource "aiven_pg_user" "lubelog_user" {
   project              = aiven_pg.this.project
   service_name         = aiven_pg.this.service_name
   username             = "lubelog-user"
-  password             = var.pg_lubelog_user_password
   pg_allow_replication = false
+
+  lifecycle {
+    ignore_changes = [password]
+  }
 }
 
 resource "null_resource" "lubelog_grants" {

--- a/terraform/modules/aiven/variables.tf
+++ b/terraform/modules/aiven/variables.tf
@@ -38,7 +38,3 @@ variable "pg_mtproxy_user_password" {
   type        = string
 }
 
-variable "pg_lubelog_user_password" {
-  description = "Password for Postgres lubelog-user"
-  type        = string
-}


### PR DESCRIPTION
## Summary

- **Image fix**: `ghcr.io/hargata/lubelogger:v1.6.7` (was `lubelog`, not `lubelogger` — root cause of all pull failures)
- **Secrets**: `LUBELOG_DB_URL` GitHub secret → `lubelog_db_url` Cloudflare KV key; workflow now passes `CLOUDFLARE_API_TOKEN`
- **Ansible**: `community.docker.docker_compose_v2` + `docker_prune` replace raw shell calls
- **Terraform**: `pg_lubelog_user_password` removed from KV data source, module arg, and variable; `lifecycle.ignore_changes = [password]` preserves the existing Aiven user password

## Before merging

1. Add `lubelog_db_url` to Cloudflare KV (copy value from GitHub secret `LUBELOG_DB_URL`)
2. Delete `pg_lubelog_user_password` from Cloudflare KV

After merge, `LUBELOG_DB_URL` GitHub secret can be removed.

This PR was created with AI assistance.