### PR TITLE
fix(lubelog): remove orphan container before deploy

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -8,7 +8,14 @@ services:
       - .env
     volumes:
       - lubelog_data:/App/data
+    networks:
+      - romashovtech_default
     restart: unless-stopped
 
 volumes:
   lubelog_data:
+
+networks:
+  romashovtech_default:
+    name: romashovtech_default
+    external: true

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/hargata/lubelogger:v1.6.7
     container_name: lubelog
     ports:
-      - 8000:8080
+      - 8080:8080
     env_file:
       - .env
     volumes:

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Create lubelog working directory
   ansible.builtin.file:
-    path: /opt/lubelog
+    path: /home/d.romashov/lubelog
     state: directory
     mode: '0750'
 
 - name: Copy docker-compose file
   ansible.builtin.copy:
     src: docker-compose.yml
-    dest: /opt/lubelog/docker-compose.yml
+    dest: /home/d.romashov/lubelog/docker-compose.yml
     mode: '0640'
 
 - name: Fetch lubelog DB URL from Cloudflare KV
@@ -24,7 +24,7 @@
 - name: Write .env file
   ansible.builtin.copy:
     content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}\n"
-    dest: /opt/lubelog/.env
+    dest: /home/d.romashov/lubelog/.env
     mode: '0600'
   no_log: true
 
@@ -35,7 +35,7 @@
 
 - name: Deploy lubelog
   community.docker.docker_compose_v2:
-    project_src: /opt/lubelog
+    project_src: /home/d.romashov/lubelog
     pull: always
     recreate: always
     state: present

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -28,10 +28,16 @@
     mode: '0600'
   no_log: true
 
+- name: Remove any existing lubelog container
+  community.docker.docker_container:
+    name: lubelog
+    state: absent
+
 - name: Deploy lubelog
   community.docker.docker_compose_v2:
     project_src: /opt/lubelog
     pull: always
+    recreate: always
     state: present
 
 - name: Remove unused docker images


### PR DESCRIPTION
## Problem

Port 8000 was already allocated by an orphaned `lubelog` container from a previous failed deploy. `docker_compose_v2` didn't know to stop it before creating a new container, so startup failed with `Bind for 0.0.0.0:8000 failed: port is already allocated`.

## Fix

- Add `docker_container: name: lubelog, state: absent` before the compose step to clean up any orphaned container
- Add `recreate: always` so the container is always recreated with a fresh state on every deploy

This PR was created with AI assistance.