### PR TITLE
feat(dns): add A record ge.romashov.tech → 91.239.206.123

### DIFF
--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -67,6 +67,15 @@ resource "cloudflare_dns_record" "a_status" {
   ttl     = 1
 }
 
+resource "cloudflare_dns_record" "a_ge" {
+  zone_id = local.zone_id
+  name    = "ge"
+  type    = "A"
+  content = "91.239.206.123"
+  proxied = false
+  ttl     = 900
+}
+
 resource "cloudflare_dns_record" "a_node1" {
   zone_id = local.zone_id
   name    = "node1"


### PR DESCRIPTION
Adds `ge.romashov.tech` pointing to the Georgia node public IP.

This PR was created with AI assistance.