### PR TITLE
fix(loki-docker-driver): install python3-requests before docker_plugin

### DIFF
--- a/ansible/roles/loki-docker-driver/tasks/main.yml
+++ b/ansible/roles/loki-docker-driver/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Install Python requests for community.docker modules
+  become: true
+  ansible.builtin.apt:
+    name:
+      - python3-requests
+    state: present
+    update_cache: yes
+
 - name: Install Loki Docker logging driver plugin
   become: true
   community.docker.docker_plugin:


### PR DESCRIPTION
## Problem

The Loki Docker logging driver install fails only on `ge.romashov.tech`:

```
Failed to import the required Python library (requests) on ge.romashov.tech's
Python /usr/bin/python3.14
```

[Failing run](https://github.com/framebassman/romashov-tech-infrastructure/actions/runs/27834509370/job/82379274008)

## Root cause

`community.docker.docker_plugin` needs the `requests` Python library **on the
target host**. `ge.romashov.tech` is in the `georgia` inventory group only — not
`vpn`/`_3xui` — so it never receives the `python3-boto3` apt package that
transitively provided `requests` on the other nodes. On ge's fresh Python 3.14,
`requests` was simply absent, so the module aborts before installing the plugin.

## Fix

Install `python3-requests` via apt at the start of the `loki-docker-driver`
role, before the `docker_plugin` task. Idempotent and host-group-agnostic, so
every node (current and future) satisfies the module's dependency.

This PR was created with AI assistance.
