### PR TITLE
feat(lubelog): move to russian node, add traefik Docker labels

### DIFF
--- a/ansible/playbooks/deploy-lubelog.yml
+++ b/ansible/playbooks/deploy-lubelog.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: georgia
+- hosts: russian
   roles:
     - lubelog

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -2,14 +2,21 @@ services:
   lubelog:
     image: ghcr.io/hargata/lubelogger:v1.6.7
     container_name: lubelog
-    ports:
-      - 8080:8080
     env_file:
       - .env
     volumes:
       - lubelog_data:/App/data
     networks:
       - romashovtech_default
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.lubelog.rule=Host(`lube.romashov.tech`)
+      - traefik.http.routers.lubelog.entrypoints=https-point
+      - traefik.http.routers.lubelog.tls=true
+      - traefik.http.routers.lubelog.middlewares=dashboard-auth@docker
+      - traefik.http.services.lubelog.loadbalancer.server.port=8080
+      - traefik.http.serverstransports.lubelogger.forwardingtimeouts.responseheadertimeout=300s
+      - traefik.http.services.lubelog.loadbalancer.serverstransport=lubelogger@docker
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- `deploy-lubelog.yml`: change `hosts: georgia` → `hosts: russian` so lubelog deploys to node2 (109.172.90.19, same host as traefik)
- `roles/lubelog/files/docker-compose.yml`: remove `ports: 8080:8080` host binding; add traefik Docker labels for routing, TLS, basic-auth middleware, and 300s response header timeout via `serversTransport`

## Why
Traefik and lubelog are on the same node. Docker socket discovery eliminates the cross-host HTTP proxy to georgia (188.120.235.164:8080).

## Data migration note
The `lubelog_data` volume currently lives on georgia. After this change lubelog starts fresh on node2. Migrate data manually if needed:
```bash
# on georgia: dump volume
docker run --rm -v lubelog_lubelog_data:/data -v /tmp:/backup alpine tar czf /backup/lubelog_data.tar.gz -C /data .
# copy to node2, restore into new volume
```

## Test plan
- [ ] `lube.romashov.tech` responds via traefik on node2
- [ ] Traefik dashboard shows `lubelog` router with docker provider

This PR was created with AI assistance.