### PR TITLE
fix(cert-sync): ignore OCSP upload errors so proxy deploys don't block

### DIFF
--- a/ansible/roles/cert-sync/tasks/upload.yml
+++ b/ansible/roles/cert-sync/tasks/upload.yml
@@ -96,6 +96,7 @@
     secret_key: "{{ CLOUDFLARE_R2_API_ACCESS_SECRET }}"
     region: us-east-1
     permission: []
+  ignore_errors: true
 
 - name: Remove temp OCSP file
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- Add `ignore_errors: true` to the OCSP DER upload step in `cert-sync/tasks/upload.yml`

## Why
The `Upload OCSP response to R2` task fails with *"Local object /tmp/vpn-cert-sync-ocsp.der does not exist"* — blocking any `deploy-proxy` run. OCSP stapling is optional for VPN clients; a missing stapled response degrades iOS Cisco Secure Client revocation checking but does not break traefik, lubelog, or anything else we're deploying now.

This unblocks the `lubelog-docker-socket` migration which needs `deploy-proxy` to run successfully.

This PR was created with AI assistance.