### PR TITLE
fix(lubelog): reference lubelogger@file serversTransport

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       - traefik.http.routers.lubelog.tls=true
       - traefik.http.routers.lubelog.middlewares=dashboard-auth@docker
       - traefik.http.services.lubelog.loadbalancer.server.port=8080
-      - traefik.http.serverstransports.lubelogger.forwardingtimeouts.responseheadertimeout=300s
-      - traefik.http.services.lubelog.loadbalancer.serverstransport=lubelogger@docker
+      - traefik.http.services.lubelog.loadbalancer.serverstransport=lubelogger@file
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- Remove `traefik.http.serverstransports.lubelogger.*` label (not supported in Traefik v3 Docker provider)
- Change `lubelogger@docker` → `lubelogger@file` in the service's `serverstransport` label

## Why
Traefik v3 ignores ServersTransport definitions via Docker labels. Referencing a non-existent `lubelogger@docker` disabled the entire lubelog router with:
> *error building proxy: getting RoundTripper: servers transport not found lubelogger@docker*

The transport now comes from the file provider (companion PR #454 in romashov-tech adds `lubelog-transport.yml`).

This PR was created with AI assistance.