### PR TITLE
feat(lubelog): use bind mount ./data instead of named volume

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - .env
     volumes:
-      - lubelog_data:/App/data
+      - ./data:/App/data
     networks:
       - romashovtech_default
     labels:
@@ -17,9 +17,6 @@ services:
       - traefik.http.services.lubelog.loadbalancer.server.port=8080
       - traefik.http.services.lubelog.loadbalancer.serverstransport=lubelogger@file
     restart: unless-stopped
-
-volumes:
-  lubelog_data:
 
 networks:
   romashovtech_default:

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -5,6 +5,12 @@
     state: directory
     mode: '0750'
 
+- name: Create lubelog data directory
+  ansible.builtin.file:
+    path: /home/d.romashov/lubelog/data
+    state: directory
+    mode: '0750'
+
 - name: Copy docker-compose file
   ansible.builtin.copy:
     src: docker-compose.yml


### PR DESCRIPTION
## Summary
- Replace `lubelog_data` named Docker volume with a bind mount `./data:/App/data`
- Add ansible task to create `/home/d.romashov/lubelog/data` before compose up
- Remove `volumes:` section from docker-compose.yml

## Why
Data is now directly accessible at `/home/d.romashov/lubelog/data` on node2 for backup, restore, and inspection. No more data loss on container recreation.

## After merge
Run `lubelog-deploy` workflow (or deploy manually). Data directory will be at `/home/d.romashov/lubelog/data`. Restore from PostgreSQL backup into that path.

This PR was created with AI assistance.