### PR TITLE
chore(lubelog): remove redundant data dir mkdir

### DIFF
--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -5,12 +5,6 @@
     state: directory
     mode: '0750'
 
-- name: Create lubelog data directory
-  ansible.builtin.file:
-    path: /home/d.romashov/lubelog/data
-    state: directory
-    mode: '0750'
-
 - name: Copy docker-compose file
   ansible.builtin.copy:
     src: docker-compose.yml


### PR DESCRIPTION
Docker Compose creates bind mount directories automatically. The explicit `Create lubelog data directory` ansible task is not needed.