### PR TITLE
feat(lubelog): add lubelog_mcp sidecar at mcp.lube.romashov.tech

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -21,8 +21,6 @@ services:
   lubelog_mcp:
     image: ghcr.io/hargata/lubelogger_mcp:latest
     container_name: lubelog_mcp
-    env_file:
-      - .env
     environment:
       - LUBELOG_INSTANCE=http://lubelog:8080
     networks:

--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -18,6 +18,26 @@ services:
       - traefik.http.services.lubelog.loadbalancer.serverstransport=lubelogger@file
     restart: unless-stopped
 
+  lubelog_mcp:
+    image: ghcr.io/hargata/lubelogger_mcp:latest
+    container_name: lubelog_mcp
+    env_file:
+      - .env
+    environment:
+      - LUBELOG_INSTANCE=http://lubelog:8080
+    networks:
+      - romashovtech_default
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.lubelog-mcp.rule=Host(`mcp.lube.romashov.tech`)
+      - traefik.http.routers.lubelog-mcp.entrypoints=https-point
+      - traefik.http.routers.lubelog-mcp.tls=true
+      - traefik.http.routers.lubelog-mcp.middlewares=dashboard-auth@docker
+      - traefik.http.services.lubelog-mcp.loadbalancer.server.port=8080
+    depends_on:
+      - lubelog
+    restart: unless-stopped
+
 networks:
   romashovtech_default:
     name: romashovtech_default

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -21,9 +21,32 @@
   register: lubelog_db_url_result
   no_log: true
 
+- name: Fetch lubelog user from Cloudflare KV
+  ansible.builtin.uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/LUBELOG_USER"
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+    return_content: true
+    status_code: 200
+  register: lubelog_user_result
+  no_log: true
+
+- name: Fetch lubelog password from Cloudflare KV
+  ansible.builtin.uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/LUBELOG_PASS"
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+    return_content: true
+    status_code: 200
+  register: lubelog_pass_result
+  no_log: true
+
 - name: Write .env file
   ansible.builtin.copy:
-    content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}\n"
+    content: |
+      ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}
+      LUBELOG_USER={{ lubelog_user_result.content }}
+      LUBELOG_PASS={{ lubelog_pass_result.content }}
     dest: /home/d.romashov/lubelog/.env
     mode: '0600'
   no_log: true
@@ -31,6 +54,11 @@
 - name: Remove any existing lubelog container
   community.docker.docker_container:
     name: lubelog
+    state: absent
+
+- name: Remove any existing lubelog_mcp container
+  community.docker.docker_container:
+    name: lubelog_mcp
     state: absent
 
 - name: Deploy lubelog

--- a/ansible/roles/lubelog/tasks/main.yml
+++ b/ansible/roles/lubelog/tasks/main.yml
@@ -21,32 +21,9 @@
   register: lubelog_db_url_result
   no_log: true
 
-- name: Fetch lubelog user from Cloudflare KV
-  ansible.builtin.uri:
-    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/LUBELOG_USER"
-    headers:
-      Authorization: "Bearer {{ cloudflare_api_token }}"
-    return_content: true
-    status_code: 200
-  register: lubelog_user_result
-  no_log: true
-
-- name: Fetch lubelog password from Cloudflare KV
-  ansible.builtin.uri:
-    url: "https://api.cloudflare.com/client/v4/accounts/4faf2c3b5dd13669f97dd976498ad56a/storage/kv/namespaces/f0b474a7601c4e16bf88e3e290db5602/values/LUBELOG_PASS"
-    headers:
-      Authorization: "Bearer {{ cloudflare_api_token }}"
-    return_content: true
-    status_code: 200
-  register: lubelog_pass_result
-  no_log: true
-
 - name: Write .env file
   ansible.builtin.copy:
-    content: |
-      ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}
-      LUBELOG_USER={{ lubelog_user_result.content }}
-      LUBELOG_PASS={{ lubelog_pass_result.content }}
+    content: "ConnectionStrings__LubeLoggerContext={{ lubelog_db_url_result.content }}\n"
     dest: /home/d.romashov/lubelog/.env
     mode: '0600'
   no_log: true

--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -37,6 +37,16 @@ resource "cloudflare_dns_record" "a_lube" {
   ttl     = 1
 }
 
+# mcp.lube.romashov.tech → node2 (RU). Traefik routes to lubelog_mcp sidecar.
+resource "cloudflare_dns_record" "a_mcp_lube" {
+  zone_id = local.zone_id
+  name    = "mcp.lube"
+  type    = "A"
+  content = "109.172.90.19"
+  proxied = false
+  ttl     = 1
+}
+
 resource "cloudflare_dns_record" "a_in_3x" {
   zone_id = local.zone_id
   name    = "in.3x"


### PR DESCRIPTION
## Summary

- Adds `lubelog_mcp` container (`ghcr.io/hargata/lubelogger_mcp:latest`) to the lubelog compose stack on node2
- MCP server connects to lubelog internally via `http://lubelog:8080` on the `romashovtech_default` network
- Exposed via Traefik on `https://mcp.lube.romashov.tech` (entrypoint `https-point`, TLS, same `dashboard-auth` basic auth as lubelog)
- Ansible role now fetches `LUBELOG_USER` and `LUBELOG_PASS` from Cloudflare KV and includes them in `.env`

## Pre-merge checklist

- [ ] Add `LUBELOG_USER` to Cloudflare KV namespace `f0b474a7...` (LubeLogger login username)
- [ ] Add `LUBELOG_PASS` to Cloudflare KV namespace `f0b474a7...` (LubeLogger login password)
- [ ] DNS record `mcp.lube.romashov.tech` → `109.172.90.19` (node2) exists

After merge, `lubelog-deploy.yml` CI will run automatically and redeploy the stack.

This PR was created with AI assistance.