### PR TITLE
fix(lubelog): rename MCP endpoint to lube-mcp.romashov.tech

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - romashovtech_default
     labels:
       - traefik.enable=true
-      - traefik.http.routers.lubelog-mcp.rule=Host(`mcp.lube.romashov.tech`)
+      - traefik.http.routers.lubelog-mcp.rule=Host(`lube-mcp.romashov.tech`)
       - traefik.http.routers.lubelog-mcp.entrypoints=https-point
       - traefik.http.routers.lubelog-mcp.tls=true
       - traefik.http.routers.lubelog-mcp.middlewares=dashboard-auth@docker

--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -37,10 +37,10 @@ resource "cloudflare_dns_record" "a_lube" {
   ttl     = 1
 }
 
-# mcp.lube.romashov.tech → node2 (RU). Traefik routes to lubelog_mcp sidecar.
-resource "cloudflare_dns_record" "a_mcp_lube" {
+# lube-mcp.romashov.tech → node2 (RU). Traefik routes to lubelog_mcp sidecar.
+resource "cloudflare_dns_record" "a_lube_mcp" {
   zone_id = local.zone_id
-  name    = "mcp.lube"
+  name    = "lube-mcp"
   type    = "A"
   content = "109.172.90.19"
   proxied = false


### PR DESCRIPTION
## Summary

`mcp.lube.romashov.tech` is three levels deep — not covered by the `*.romashov.tech` wildcard, falls back to Traefik default cert. `lube-mcp.romashov.tech` is one level and is covered.

Changes:
- Traefik router rule: `mcp.lube.romashov.tech` → `lube-mcp.romashov.tech`
- Cloudflare DNS A record: `mcp.lube` → `lube-mcp` (resource renamed `a_mcp_lube` → `a_lube_mcp`, terraform will delete old + create new)

After merge, `deploy.yml` runs terraform (removes old DNS record, creates new one) and `lubelog-deploy.yml` redeploys the stack with the updated Traefik label.

This PR was created with AI assistance.