### PR TITLE
fix(lubelog): rename MCP endpoint to mcp-lube.romashov.tech

### DIFF
--- a/ansible/roles/lubelog/files/docker-compose.yml
+++ b/ansible/roles/lubelog/files/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - romashovtech_default
     labels:
       - traefik.enable=true
-      - traefik.http.routers.lubelog-mcp.rule=Host(`lube-mcp.romashov.tech`)
+      - traefik.http.routers.lubelog-mcp.rule=Host(`mcp-lube.romashov.tech`)
       - traefik.http.routers.lubelog-mcp.entrypoints=https-point
       - traefik.http.routers.lubelog-mcp.tls=true
       - traefik.http.routers.lubelog-mcp.middlewares=dashboard-auth@docker

--- a/terraform/modules/cloudflare/dns.tf
+++ b/terraform/modules/cloudflare/dns.tf
@@ -37,10 +37,10 @@ resource "cloudflare_dns_record" "a_lube" {
   ttl     = 1
 }
 
-# lube-mcp.romashov.tech → node2 (RU). Traefik routes to lubelog_mcp sidecar.
-resource "cloudflare_dns_record" "a_lube_mcp" {
+# mcp-lube.romashov.tech → node2 (RU). Traefik routes to lubelog_mcp sidecar.
+resource "cloudflare_dns_record" "a_mcp_lube" {
   zone_id = local.zone_id
-  name    = "lube-mcp"
+  name    = "mcp-lube"
   type    = "A"
   content = "109.172.90.19"
   proxied = false


### PR DESCRIPTION
\`lube-mcp\` → \`mcp-lube\` to follow service-first naming convention (service name first, then qualifier).

Renames Traefik router rule and Cloudflare DNS record accordingly.

This PR was created with AI assistance.